### PR TITLE
Implement golangci-lint for Go code quality

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,56 @@
+# golangci-lint configuration for Spotter
+# See: https://golangci-lint.run/usage/configuration/
+
+run:
+  timeout: 5m
+  tests: true
+
+linters:
+  enable:
+    - govet          # Go vet examines Go source code and reports suspicious constructs
+    - staticcheck    # Staticcheck is a go vet on steroids
+    - errcheck       # Errcheck checks for unchecked errors
+    - gosimple       # Linter for Go source code that specializes in simplifying code
+    - ineffassign    # Detects when assignments to existing variables are not used
+    - unused         # Checks Go code for unused constants, variables, functions and types
+    - gofmt          # Gofmt checks whether code was gofmt-ed
+    - goimports      # Check import statements are formatted according to the 'goimport' command
+    - misspell       # Finds commonly misspelled English words in comments
+    - revive         # Fast, configurable, extensible, flexible, and beautiful linter for Go
+    - typecheck      # Like the front-end of a Go compiler, parses and type-checks Go code
+    - goconst        # Finds repeated strings that could be replaced by a constant
+    - unconvert      # Remove unnecessary type conversions
+    - gocritic       # Provides diagnostics that check for bugs, performance and style issues
+
+linters-settings:
+  govet:
+    enable-all: true
+
+  errcheck:
+    check-type-assertions: true
+    check-blank: true
+
+  revive:
+    confidence: 0.8
+
+  goimports:
+    local-prefixes: github.com/joestump/spotter
+
+issues:
+  exclude-use-default: false
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+  # Exclude generated code directories and files
+  exclude-dirs:
+    - ent  # Exclude generated Ent code
+  exclude-files:
+    - ".*_gen\\.go$"      # Exclude *_gen.go files
+    - ".*_templ\\.go$"    # Exclude Templ generated files
+
+  # Exclude some linters from running on tests files
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - errcheck
+        - goconst

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ endif
 BINARY_NAME=spotter-server
 MAIN_PATH=./cmd/server/main.go
 
-.PHONY: all help deps ci-deps docker-deps generate css build build-binary run dev test test-coverage clean docker-build docker-run
+.PHONY: all help deps ci-deps docker-deps generate css build build-binary run dev test test-coverage lint-go clean docker-build docker-run
 
 all: build
 
@@ -23,6 +23,7 @@ deps: ## Install all dependencies (Go, Node, tools)
 	@echo "Installing development tools..."
 	go install github.com/a-h/templ/cmd/templ@latest
 	go install github.com/air-verse/air@latest
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	@echo "Installing Node dependencies..."
 	npm install
 	@echo "✓ Dependencies installed"
@@ -32,6 +33,8 @@ ci-deps: ## Install CI dependencies (minimal, no dev tools)
 	go mod download
 	@echo "Installing templ..."
 	go install github.com/a-h/templ/cmd/templ@latest
+	@echo "Installing golangci-lint..."
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	@echo "✓ CI dependencies installed"
 
 docker-deps: ## Install Docker build dependencies (Go, templ, Node)
@@ -87,6 +90,11 @@ test-coverage: generate ## Run tests with coverage report
 	go test -v -coverprofile=coverage.out ./...
 	go tool cover -html=coverage.out -o coverage.html
 	@echo "✓ Coverage report generated: coverage.html"
+
+lint-go: ## Run golangci-lint on Go code
+	@echo "Running golangci-lint..."
+	@golangci-lint run ./...
+	@echo "✓ Go linting passed"
 
 clean: ## Remove build artifacts
 	@echo "Cleaning build artifacts..."


### PR DESCRIPTION
Add golangci-lint configuration and Makefile integration as part of linting infrastructure (spotter-flb epic).

Changes:
- Create `.golangci.yml` with 14 enabled linters (exceeds requirement of 10)
- Exclude generated code (ent/, *_gen.go, *_templ.go)
- Set 5-minute timeout for linting runs
- Add `make lint-go` target to run golangci-lint
- Install golangci-lint in `make deps` and `make ci-deps`
- Update .PHONY declarations

Enabled linters:
- govet, staticcheck, errcheck, gosimple, ineffassign, unused
- gofmt, goimports, misspell, revive, typecheck
- goconst, unconvert, gocritic

Addresses: spotter-flb.1