### PR TITLE
Add unified 'make lint' target to run all linters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ endif
 BINARY_NAME=spotter-server
 MAIN_PATH=./cmd/server/main.go
 
-.PHONY: all help deps ci-deps docker-deps generate css build build-binary run dev test test-coverage lint-docker lint-go lint-md lint-templ lint-yaml clean docker-build docker-run
+.PHONY: all help deps ci-deps docker-deps generate css build build-binary run dev test test-coverage lint lint-docker lint-go lint-md lint-templ lint-yaml clean docker-build docker-run
 
 all: build
 
@@ -90,6 +90,26 @@ test-coverage: generate ## Run tests with coverage report
 	go test -v -coverprofile=coverage.out ./...
 	go tool cover -html=coverage.out -o coverage.html
 	@echo "✓ Coverage report generated: coverage.html"
+
+lint: ## Run all linters
+	@echo "Running all linters..."
+	@echo ""
+	@echo "→ Go (golangci-lint)..."
+	@$(MAKE) lint-go
+	@echo ""
+	@echo "→ Templ templates..."
+	@$(MAKE) lint-templ
+	@echo ""
+	@echo "→ YAML files..."
+	@$(MAKE) lint-yaml
+	@echo ""
+	@echo "→ Markdown files..."
+	@$(MAKE) lint-md
+	@echo ""
+	@echo "→ Dockerfile..."
+	@$(MAKE) lint-docker
+	@echo ""
+	@echo "✓ All linters passed"
 
 lint-yaml: ## Run yamllint on YAML files
 	@echo "Linting YAML files..."


### PR DESCRIPTION
Create a single make target that runs all linting tools in sequence with clear output sections for each linter.

Changes:
- Add `lint` target that orchestrates all individual linters
- Runs lint-go, lint-templ, lint-yaml, lint-md, lint-docker in sequence
- Clear section headers for each linter with arrow indicators
- Fails with non-zero exit code if any linter fails (fail-fast)
- Add `lint` to .PHONY declarations
- Helpful output showing which linter is running and final success

Usage: `make lint`

Addresses: spotter-flb.6