### PR TITLE
Add input validation helpers and schema length constraints

### DIFF
--- a/ent/schema/album.go
+++ b/ent/schema/album.go
@@ -28,27 +28,34 @@ type Album struct {
 func (Album) Fields() []ent.Field {
 	return []ent.Field{
 		field.String("name").
-			NotEmpty(),
+			NotEmpty().
+			MaxLen(500),
 		field.String("sort_name").
 			Optional().
+			MaxLen(500).
 			Comment("Name used for sorting, e.g., 'White Album, The'"),
 		field.String("musicbrainz_id").
 			Optional().
+			MaxLen(36).
 			Comment("MusicBrainz release group ID"),
 		field.String("spotify_id").
 			Optional().
+			MaxLen(50).
 			Comment("Spotify album ID"),
 		field.String("lidarr_id").
 			Optional().
+			MaxLen(255).
 			Comment("Lidarr album ID"),
 		field.String("release_date").
 			Optional().
+			MaxLen(10).
 			Comment("Release date in ISO format (YYYY, YYYY-MM, or YYYY-MM-DD)"),
 		field.Int("year").
 			Optional().
 			Comment("Release year extracted from release_date"),
 		field.String("genre").
 			Optional().
+			MaxLen(255).
 			Comment("Primary genre of the album"),
 		field.JSON("tags", []string{}).
 			Optional().
@@ -61,9 +68,11 @@ func (Album) Fields() []ent.Field {
 			Comment("Total number of tracks on the album"),
 		field.String("album_type").
 			Optional().
+			MaxLen(50).
 			Comment("Type: album, single, compilation, ep"),
 		field.String("label").
 			Optional().
+			MaxLen(255).
 			Comment("Record label"),
 		field.Time("created_at").
 			Default(time.Now).
@@ -77,6 +86,7 @@ func (Album) Fields() []ent.Field {
 		// AI-generated fields
 		field.Text("ai_summary").
 			Optional().
+			MaxLen(10000).
 			Comment("AI-generated summary of the album including artist thoughts and context"),
 		field.JSON("ai_tags", []string{}).
 			Optional().
@@ -86,6 +96,7 @@ func (Album) Fields() []ent.Field {
 			Comment("AI-generated dominant colors from the cover art"),
 		field.Text("cover_art_commentary").
 			Optional().
+			MaxLen(10000).
 			Comment("AI-generated art critic commentary on the cover art"),
 		field.Time("last_ai_enriched_at").
 			Optional().

--- a/ent/schema/artist.go
+++ b/ent/schema/artist.go
@@ -19,29 +19,37 @@ func (Artist) Fields() []ent.Field {
 	return []ent.Field{
 		field.String("name").
 			NotEmpty().
+			MaxLen(500).
 			Comment("Artist name"),
 		field.String("sort_name").
 			Optional().
+			MaxLen(500).
 			Comment("Name used for sorting, e.g., 'Beatles, The'"),
 		field.String("musicbrainz_id").
 			Optional().
 			Unique().
+			MaxLen(36). // UUID format
 			Comment("MusicBrainz artist MBID"),
 		field.String("spotify_id").
 			Optional().
 			Unique().
+			MaxLen(50).
 			Comment("Spotify artist ID"),
 		field.String("lastfm_url").
 			Optional().
+			MaxLen(2048).
 			Comment("Last.fm artist page URL"),
 		field.String("navidrome_id").
 			Optional().
+			MaxLen(255).
 			Comment("Navidrome artist ID"),
 		field.String("lidarr_id").
 			Optional().
+			MaxLen(255).
 			Comment("Lidarr artist ID"),
 		field.Text("bio").
 			Optional().
+			MaxLen(50000). // Bios can be long
 			Comment("Artist biography from Last.fm or other sources"),
 		field.JSON("tags", []string{}).
 			Optional().
@@ -70,9 +78,11 @@ func (Artist) Fields() []ent.Field {
 		// AI-generated fields
 		field.Text("ai_summary").
 			Optional().
+			MaxLen(10000).
 			Comment("AI-generated summary of the artist"),
 		field.Text("ai_biography").
 			Optional().
+			MaxLen(50000).
 			Comment("AI-generated biography for the artist"),
 		field.JSON("ai_tags", []string{}).
 			Optional().

--- a/ent/schema/dj.go
+++ b/ent/schema/dj.go
@@ -19,9 +19,11 @@ func (DJ) Fields() []ent.Field {
 	return []ent.Field{
 		field.String("name").
 			NotEmpty().
+			MaxLen(255).
 			Comment("User-given name for this DJ"),
 		field.Text("system_prompt").
 			Optional().
+			MaxLen(10000).
 			Comment("Custom system prompt defining the DJ's personality"),
 		field.Strings("genres_include").
 			Optional().

--- a/ent/schema/mixtape.go
+++ b/ent/schema/mixtape.go
@@ -19,12 +19,15 @@ func (Mixtape) Fields() []ent.Field {
 	return []ent.Field{
 		field.String("name").
 			NotEmpty().
+			MaxLen(500).
 			Comment("User-given name for this mixtape"),
 		field.String("description").
 			Optional().
+			MaxLen(2000).
 			Comment("Optional description of the mixtape"),
 		field.String("image_url").
 			Optional().
+			MaxLen(2048).
 			Comment("URL to the mixtape cover art"),
 		field.Enum("schedule").
 			Values("none", "daily", "weekly", "monthly").
@@ -35,6 +38,7 @@ func (Mixtape) Fields() []ent.Field {
 			Comment("Whether to sync this mixtape as a playlist in Navidrome"),
 		field.String("navidrome_playlist_id").
 			Optional().
+			MaxLen(255).
 			Comment("The remote playlist ID in Navidrome if synced"),
 		field.Int("track_count").
 			Default(0).
@@ -54,12 +58,15 @@ func (Mixtape) Fields() []ent.Field {
 			Comment("Number of tokens used in the last generation"),
 		field.String("generation_model").
 			Optional().
+			MaxLen(100).
 			Comment("The AI model used for the last generation"),
 		field.String("generation_error").
 			Optional().
+			MaxLen(1000).
 			Comment("Error message from the last generation attempt, empty if successful"),
 		field.String("seed_type").
 			Optional().
+			MaxLen(50).
 			Comment("Type of seed data used: artist, album, tracks, or empty for DJ-only"),
 		field.Int("seed_id").
 			Optional().

--- a/ent/schema/playlist.go
+++ b/ent/schema/playlist.go
@@ -17,18 +17,24 @@ type Playlist struct {
 // Fields of the Playlist.
 func (Playlist) Fields() []ent.Field {
 	return []ent.Field{
-		field.String("remote_id"),
+		field.String("remote_id").
+			MaxLen(255),
 		field.String("name").
-			NotEmpty(),
+			NotEmpty().
+			MaxLen(500),
 		field.String("description").
-			Optional(),
+			Optional().
+			MaxLen(2000),
 		field.String("source").
-			NotEmpty(), // e.g. "spotify", "navidrome"
+			NotEmpty().
+			MaxLen(50), // e.g. "spotify", "navidrome"
 		field.String("image_url").
 			Optional().
+			MaxLen(2048).
 			Comment("URL to the playlist cover art"),
 		field.String("external_url").
 			Optional().
+			MaxLen(2048).
 			Comment("Deep link to the playlist on the provider's website"),
 		field.Int("track_count").
 			Default(0).
@@ -44,6 +50,7 @@ func (Playlist) Fields() []ent.Field {
 			Comment("Whether to sync this playlist to Navidrome (only for non-Navidrome sources)"),
 		field.String("navidrome_playlist_id").
 			Optional().
+			MaxLen(255).
 			Comment("The remote playlist ID in Navidrome if synced from another source"),
 		field.Time("last_synced_at").
 			Optional().
@@ -51,6 +58,7 @@ func (Playlist) Fields() []ent.Field {
 			Comment("When the playlist was last synced to Navidrome"),
 		field.String("sync_error").
 			Optional().
+			MaxLen(1000).
 			Comment("Last sync error message, empty if successful"),
 		field.Int("matched_track_count").
 			Default(0).

--- a/ent/schema/user.go
+++ b/ent/schema/user.go
@@ -17,13 +17,18 @@ type User struct {
 func (User) Fields() []ent.Field {
 	return []ent.Field{
 		field.String("username").
-			Unique(),
+			Unique().
+			NotEmpty().
+			MaxLen(255),
 		field.String("email").
-			Optional(),
+			Optional().
+			MaxLen(320), // RFC 5321 max email length
 		field.String("theme").
-			Default("dark"),
+			Default("dark").
+			MaxLen(50),
 		field.Text("system_prompt").
-			Optional(),
+			Optional().
+			MaxLen(10000), // Reasonable limit for AI prompts
 		field.Int("pagination_size").
 			Default(25),
 		field.Time("last_login_at").

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -33,6 +33,12 @@ func (h *Handler) PostLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Validate input lengths to prevent abuse
+	if err := ValidateMaxLength("username", username, MaxNameLength); err != nil {
+		h.BadRequest(w, err)
+		return
+	}
+
 	// 1. Authenticate against Navidrome
 	if err := h.authenticateNavidrome(username, password); err != nil {
 		h.Logger.Error("Navidrome authentication failed", "error", err)

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -2,8 +2,10 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"spotter/ent"
 	"spotter/internal/config"
@@ -13,6 +15,14 @@ import (
 	"spotter/internal/vibes"
 
 	"github.com/a-h/templ"
+)
+
+// Input validation constants
+const (
+	MaxNameLength        = 255
+	MaxDescriptionLength = 2000
+	MaxPromptLength      = 10000
+	MaxURLLength         = 2048
 )
 
 type contextKey string
@@ -63,4 +73,63 @@ func (h *Handler) GetUser(ctx context.Context) *ent.User {
 		return nil
 	}
 	return u
+}
+
+// ValidationError represents an input validation error
+type ValidationError struct {
+	Field   string
+	Message string
+}
+
+func (e *ValidationError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Field, e.Message)
+}
+
+// ValidateRequired checks that a string field is not empty
+func ValidateRequired(field, value string) *ValidationError {
+	if value == "" {
+		return &ValidationError{Field: field, Message: "is required"}
+	}
+	return nil
+}
+
+// ValidateMaxLength checks that a string doesn't exceed the maximum length
+func ValidateMaxLength(field, value string, maxLen int) *ValidationError {
+	if len(value) > maxLen {
+		return &ValidationError{Field: field, Message: fmt.Sprintf("exceeds maximum length of %d characters", maxLen)}
+	}
+	return nil
+}
+
+// ValidateRange checks that an integer is within the specified range
+func ValidateRange(field string, value, min, max int) *ValidationError {
+	if value < min || value > max {
+		return &ValidationError{Field: field, Message: fmt.Sprintf("must be between %d and %d", min, max)}
+	}
+	return nil
+}
+
+// BadRequest sends a 400 response with the validation error message
+func (h *Handler) BadRequest(w http.ResponseWriter, err *ValidationError) {
+	http.Error(w, err.Error(), http.StatusBadRequest)
+}
+
+// ValidateTimestamp checks that a string is a valid RFC3339 timestamp
+func ValidateTimestamp(field, value string) *ValidationError {
+	if value == "" {
+		return nil // Empty is ok if field is optional
+	}
+	if _, err := time.Parse(time.RFC3339, value); err != nil {
+		return &ValidationError{Field: field, Message: "must be a valid RFC3339 timestamp (e.g., 2006-01-02T15:04:05Z)"}
+	}
+	return nil
+}
+
+// ParseTimestamp parses a string as RFC3339 timestamp, returning an error if invalid
+func ParseTimestamp(field, value string) (time.Time, *ValidationError) {
+	t, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return time.Time{}, &ValidationError{Field: field, Message: "must be a valid RFC3339 timestamp (e.g., 2006-01-02T15:04:05Z)"}
+	}
+	return t, nil
 }

--- a/internal/handlers/vibes.go
+++ b/internal/handlers/vibes.go
@@ -93,12 +93,21 @@ func (h *Handler) CreateDJ(w http.ResponseWriter, r *http.Request) {
 	}
 
 	name := strings.TrimSpace(r.FormValue("name"))
-	if name == "" {
-		http.Error(w, "Name is required", http.StatusBadRequest)
+	if err := ValidateRequired("name", name); err != nil {
+		h.BadRequest(w, err)
+		return
+	}
+	if err := ValidateMaxLength("name", name, MaxNameLength); err != nil {
+		h.BadRequest(w, err)
 		return
 	}
 
 	systemPrompt := strings.TrimSpace(r.FormValue("system_prompt"))
+	if err := ValidateMaxLength("system_prompt", systemPrompt, MaxPromptLength); err != nil {
+		h.BadRequest(w, err)
+		return
+	}
+
 	genresInclude := parseCommaSeparated(r.FormValue("genres_include"))
 	genresExclude := parseCommaSeparated(r.FormValue("genres_exclude"))
 	vibesTags := parseCommaSeparated(r.FormValue("vibes"))
@@ -155,12 +164,21 @@ func (h *Handler) UpdateDJ(w http.ResponseWriter, r *http.Request) {
 	}
 
 	name := strings.TrimSpace(r.FormValue("name"))
-	if name == "" {
-		http.Error(w, "Name is required", http.StatusBadRequest)
+	if err := ValidateRequired("name", name); err != nil {
+		h.BadRequest(w, err)
+		return
+	}
+	if err := ValidateMaxLength("name", name, MaxNameLength); err != nil {
+		h.BadRequest(w, err)
 		return
 	}
 
 	systemPrompt := strings.TrimSpace(r.FormValue("system_prompt"))
+	if err := ValidateMaxLength("system_prompt", systemPrompt, MaxPromptLength); err != nil {
+		h.BadRequest(w, err)
+		return
+	}
+
 	genresInclude := parseCommaSeparated(r.FormValue("genres_include"))
 	genresExclude := parseCommaSeparated(r.FormValue("genres_exclude"))
 	vibesTags := parseCommaSeparated(r.FormValue("vibes"))
@@ -303,12 +321,21 @@ func (h *Handler) CreateMixtape(w http.ResponseWriter, r *http.Request) {
 	}
 
 	name := strings.TrimSpace(r.FormValue("name"))
-	if name == "" {
-		http.Error(w, "Name is required", http.StatusBadRequest)
+	if err := ValidateRequired("name", name); err != nil {
+		h.BadRequest(w, err)
+		return
+	}
+	if err := ValidateMaxLength("name", name, MaxNameLength); err != nil {
+		h.BadRequest(w, err)
 		return
 	}
 
 	description := strings.TrimSpace(r.FormValue("description"))
+	if err := ValidateMaxLength("description", description, MaxDescriptionLength); err != nil {
+		h.BadRequest(w, err)
+		return
+	}
+
 	schedule := r.FormValue("schedule")
 	if schedule == "" {
 		schedule = "none"
@@ -394,12 +421,21 @@ func (h *Handler) UpdateMixtape(w http.ResponseWriter, r *http.Request) {
 	}
 
 	name := strings.TrimSpace(r.FormValue("name"))
-	if name == "" {
-		http.Error(w, "Name is required", http.StatusBadRequest)
+	if err := ValidateRequired("name", name); err != nil {
+		h.BadRequest(w, err)
+		return
+	}
+	if err := ValidateMaxLength("name", name, MaxNameLength); err != nil {
+		h.BadRequest(w, err)
 		return
 	}
 
 	description := strings.TrimSpace(r.FormValue("description"))
+	if err := ValidateMaxLength("description", description, MaxDescriptionLength); err != nil {
+		h.BadRequest(w, err)
+		return
+	}
+
 	schedule := r.FormValue("schedule")
 	if schedule == "" {
 		schedule = "none"


### PR DESCRIPTION
## Summary
- Add MaxLen validators to ent schemas (User, DJ, Playlist, Mixtape, Artist, Album) to prevent buffer overflows
- Add validation helpers (ValidateRequired, ValidateMaxLength, ValidateRange, ValidateTimestamp, ParseTimestamp) to handlers.go
- Update CreateDJ, UpdateDJ, CreateMixtape, UpdateMixtape handlers to use consistent validation
- Add username length validation to PostLogin for defense in depth

## Changes
- **Schema validation**: All string fields now have MaxLen constraints in ent schemas
- **Handler validation**: New validation helper functions provide consistent 400 Bad Request responses
- **Timestamp validation**: RFC3339 validation helpers ready for future use when timestamp filters are added

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] Linter passes (`make lint`)
- [x] Manual verification of validation error messages

Closes: spotter-5rf, spotter-ikt, spotter-fe1, spotter-r09

🤖 Generated with [Claude Code](https://claude.com/claude-code)