### PR TITLE
Add documentation build to CI linting pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Install Node dependencies
         run: npm install
 
+      - name: Install documentation dependencies
+        run: cd website && npm install
+
       - name: Install yamllint
         run: pip install yamllint
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -821,9 +821,41 @@ npm run deploy
 
 ### Documentation Linting
 
-Documentation markdown is linted by `make lint-md`. The `.markdownlint.json` config is set up for Docusaurus compatibility.
+Documentation is validated in two ways:
 
-**Common fixes:**
+1. **Markdown linting** (`make lint-md`) - Enforces consistent formatting
+2. **Docusaurus build** (`make lint-docs`) - Validates links and structure
+
+Both run automatically as part of `make lint`.
+
+**Running documentation checks:**
+```bash
+make lint          # Run all linters including docs build
+make lint-md       # Markdown formatting only
+make lint-docs     # Docusaurus build only (catches broken links)
+```
+
+**Before submitting PRs that touch `website/`:**
+```bash
+cd website && npm run build   # Or: make lint-docs
+```
+
+The Docusaurus build will **fail on broken links** (`onBrokenLinks: 'throw'` in config).
+
+**Common link patterns and pitfalls:**
+
+| Pattern | Correct | Incorrect |
+|---------|---------|-----------|
+| Internal docs | `/docs/getting-started/installation` | `/docs/getting-started` (missing page) |
+| Section links | `/docs/features/themes` | `/docs/configuration` (wrong path) |
+| Relative links | `./configuration` | `../configuration` (wrong level) |
+
+**Common link errors:**
+- Missing `/installation` or `/configuration` suffix on getting-started links
+- Linking to category folders instead of actual pages
+- Typos in document slugs
+
+**Markdown formatting fixes:**
 - Use allowed HTML elements (details, summary, div, span)
 - Avoid inline HTML when possible
 - Add blank lines around code blocks

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ endif
 BINARY_NAME=spotter-server
 MAIN_PATH=./cmd/server/main.go
 
-.PHONY: all help deps ci-deps docker-deps generate css build build-binary run dev test test-coverage lint lint-docker lint-go lint-md lint-templ lint-yaml clean docker-build docker-run docs-deps docs-build docs-serve docs-clean
+.PHONY: all help deps ci-deps docker-deps generate css build build-binary run dev test test-coverage lint lint-docker lint-docs lint-go lint-md lint-templ lint-yaml clean docker-build docker-run docs-deps docs-build docs-serve docs-clean
 
 all: build
 
@@ -111,6 +111,9 @@ lint: ## Run all linters
 	@echo "→ Dockerfile..."
 	@$(MAKE) lint-docker
 	@echo ""
+	@echo "→ Documentation (Docusaurus build)..."
+	@$(MAKE) lint-docs
+	@echo ""
 	@echo "✓ All linters passed"
 
 lint-yaml: ## Run yamllint on YAML files
@@ -132,6 +135,11 @@ lint-md: ## Run markdownlint on Markdown files
 	@echo "Linting Markdown files..."
 	@npx markdownlint "**/*.md" --ignore node_modules --ignore .beads --ignore "website/node_modules"
 	@echo "✓ Markdown linting passed"
+
+lint-docs: ## Build Docusaurus docs (checks for broken links)
+	@echo "Building documentation to check for broken links..."
+	@cd website && npm run build
+	@echo "✓ Documentation build passed"
 
 lint-go: generate ## Run golangci-lint on Go code
 	@echo "Running golangci-lint..."

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -93,11 +93,11 @@ const config: Config = {
           items: [
             {
               label: 'Getting Started',
-              to: '/docs/getting-started',
+              to: '/docs/getting-started/installation',
             },
             {
               label: 'Configuration',
-              to: '/docs/configuration',
+              to: '/docs/getting-started/configuration',
             },
           ],
         },


### PR DESCRIPTION
## Summary
- Fix broken footer links in `docusaurus.config.ts` (`/docs/getting-started` -> `/docs/getting-started/installation`, `/docs/configuration` -> `/docs/getting-started/configuration`)
- Add `lint-docs` target to Makefile that builds Docusaurus to catch broken links
- Add `lint-docs` to the main `lint` target so it runs with all other linters
- Add website npm install step to GitHub Actions CI workflow
- Update AGENTS.md with comprehensive documentation linting workflow and common pitfalls

## Test plan
- [x] `make lint-docs` passes locally
- [x] `make lint` passes locally (includes docs build)
- [ ] CI workflow runs successfully

## Issues closed
- spotter-5zl: Documentation Quality: Fix broken links and add CI linting (epic)
- spotter-wzs: Fix broken footer links in docusaurus.config.ts
- spotter-2hd: Add Docusaurus build to make lint target
- spotter-68i: Add Docusaurus build step to GitHub Actions CI
- spotter-jbn: Update AGENTS.md with documentation linting workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
