### PR TITLE
Last.fm Authentication Flow

### DIFF
--- a/internal/handlers/lastfm_auth.go
+++ b/internal/handlers/lastfm_auth.go
@@ -19,6 +19,7 @@ const (
 )
 
 // LastFMLogin initiates the Last.fm authentication flow.
+// Governing: ADR-0005 (Navidrome primary identity), ADR-0006 (AES-256-GCM), ADR-0007 (event bus), SPEC user-authentication REQ "LASTFM-001" through "LASTFM-004"
 func (h *Handler) LastFMLogin(w http.ResponseWriter, r *http.Request) {
 	u := h.GetUser(r.Context())
 	if u == nil {
@@ -75,6 +76,7 @@ func (h *Handler) LastFMLogin(w http.ResponseWriter, r *http.Request) {
 }
 
 // LastFMCallback handles the callback from Last.fm.
+// Governing: ADR-0005, ADR-0006 (AES-256-GCM), ADR-0007 (event bus), SPEC user-authentication REQ "LASTFM-005", REQ "LASTFM-006"
 func (h *Handler) LastFMCallback(w http.ResponseWriter, r *http.Request) {
 	// Get authorization token
 	token := r.URL.Query().Get("token")


### PR DESCRIPTION
## Summary
- Verifies Last.fm token-based authentication flow with cookie-based state recovery and encrypted session key storage satisfies all SPEC user-authentication REQ-LASTFM-* requirements
- Adds governing comments to `LastFMLogin` and `LastFMCallback` tracing implementation back to ADR-0005, ADR-0006, ADR-0007, and SPEC user-authentication

Closes #44
Part of #30 — SPEC user-authentication

## Governing
ADR-0005 (Navidrome primary identity), ADR-0006 (AES-256-GCM), ADR-0007 (event bus)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/handlers/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)