### PR TITLE
AuthMiddleware Request Authentication

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -361,6 +361,7 @@ func runMetadataSync(client *ent.Client, metadataSvc *services.MetadataService, 
 	}
 }
 
+// Governing: ADR-0005 (Navidrome primary identity), ADR-0002 (Chi router), SPEC user-authentication REQ "MIDDLEWARE-001", REQ "MIDDLEWARE-002", REQ "MIDDLEWARE-003", REQ "MIDDLEWARE-004"
 func AuthMiddleware(client *ent.Client, jwtManager *auth.JWTManager, logger *slog.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -73,6 +73,7 @@ func (h *Handler) Render(w http.ResponseWriter, r *http.Request, component templ
 	}
 }
 
+// Governing: SPEC user-authentication REQ "MIDDLEWARE-005"
 func (h *Handler) GetUser(ctx context.Context) *ent.User {
 	u, ok := ctx.Value(UserContextKey).(*ent.User)
 	if !ok {


### PR DESCRIPTION
## Summary
Verifies and adds governing comments to the AuthMiddleware function and GetUser helper that protect routes by validating session cookies and injecting authenticated users into request context.

Implements all REQ-MIDDLEWARE-* requirements from SPEC user-authentication.

Closes #40
Part of #30 — SPEC user-authentication

## Governing
ADR-0005 (Navidrome primary identity), ADR-0002 (Chi router)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] All REQ-MIDDLEWARE-001 through REQ-MIDDLEWARE-005 verified in code

🤖 Generated with [Claude Code](https://claude.com/claude-code)