### PR TITLE
Load hyperscript library in base layout to fix modal interactions

### DIFF
--- a/internal/views/layouts/base.templ
+++ b/internal/views/layouts/base.templ
@@ -21,6 +21,8 @@ templ BaseWithTheme(title string, defaultTheme string) {
 			<title>{ title }</title>
 			<script src="https://unpkg.com/htmx.org@1.9.10"></script>
 			<script src="https://unpkg.com/htmx.org@1.9.10/dist/ext/sse.js"></script>
+			// Hyperscript: required for _="..." attributes in create_mixtape_modal, enhance_vibes_modal
+			<script src="https://unpkg.com/hyperscript.org@0.9.12"></script>
 			<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 			<script src="https://cdnjs.cloudflare.com/ajax/libs/timeago.js/4.0.2/timeago.min.js"></script>
 			<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>


### PR DESCRIPTION
## Summary
- Add hyperscript.org script to base layout
- Required for `_="..."` attributes used in create_mixtape_modal and enhance_vibes_modal
- Without this, opening modals via HTMX requests silently fails

Fixes #109

🤖 Generated with Claude Code