### PR TITLE
Fix GenerateMixtape goroutine using cancelled r.Context()

### DIFF
--- a/internal/handlers/vibes.go
+++ b/internal/handlers/vibes.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"sort"
@@ -657,7 +658,8 @@ func (h *Handler) GenerateMixtape(w http.ResponseWriter, r *http.Request) {
 
 	// Run generation (this can take a while, so we do it in a goroutine for async UX)
 	go func() {
-		ctx := r.Context()
+		// Governing: context.Background() prevents premature cancellation when HTTP handler returns
+		ctx := context.Background()
 
 		// Publish generating event
 		if h.Bus != nil {


### PR DESCRIPTION
## Summary
- Fix goroutine in GenerateMixtape using r.Context() which is cancelled when handler returns
- Changed to context.Background() to allow AI generation to complete

Fixes #87

🤖 Generated with Claude Code