### PR TITLE
Implement observability: structured metrics via slog metric events

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -39,10 +40,10 @@ import (
 )
 
 func main() {
-	opts := &slog.HandlerOptions{
-		Level: slog.LevelDebug,
-	}
-	logger := slog.New(slog.NewTextHandler(os.Stdout, opts))
+	// Governing: ADR-0019 (structured metrics), ADR-0010 (slog), SPEC observability REQ "FMT-001", REQ "FMT-002", REQ "FMT-003", REQ "FMT-004", REQ "FMT-005"
+	// Bootstrap logger with text handler; will be replaced after config load
+	bootstrapOpts := &slog.HandlerOptions{Level: slog.LevelDebug}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, bootstrapOpts))
 
 	// Load Config
 	cfg, err := config.Load()
@@ -50,6 +51,19 @@ func main() {
 		logger.Error("failed to load config", "error", err)
 		os.Exit(1)
 	}
+
+	// Re-initialize logger with configured format
+	opts := &slog.HandlerOptions{Level: slog.LevelDebug}
+	format := strings.ToLower(cfg.Log.Format)
+	if format != "json" {
+		format = "text" // REQ "FMT-002": invalid values default to text
+	}
+	if format == "json" {
+		logger = slog.New(slog.NewJSONHandler(os.Stdout, opts))
+	} else {
+		logger = slog.New(slog.NewTextHandler(os.Stdout, opts))
+	}
+	logger.Info("logger initialized", "format", format, "level", "debug")
 
 	// Initialize encryption for sensitive data
 	encryptionKey, err := cfg.GetEncryptionKeyBytes()
@@ -152,6 +166,7 @@ func main() {
 	}
 	logger.Info("background sync configured", "interval", syncInterval)
 
+	// Governing: ADR-0019 (structured metrics), SPEC observability REQ "BG-001", REQ "BG-002"
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -162,12 +177,14 @@ func main() {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
+				tickStart := time.Now()
 				// Governing: SPEC graceful-shutdown REQ-CTX-003 (per-user goroutines use root ctx)
 				users, err := client.User.Query().All(ctx)
 				if err != nil {
 					logger.Error("failed to fetch users for background sync", "error", err)
 					continue
 				}
+				syncErrors := 0
 				for _, u := range users {
 					// Governing: SPEC graceful-shutdown REQ-WG-002 (wg.Add before spawn, defer wg.Done first)
 					wg.Add(1)
@@ -182,9 +199,15 @@ func main() {
 						}
 						if err := syncer.Sync(ctx, user); err != nil {
 							logger.Error("background sync failed", "username", user.Username, "error", err)
+							syncErrors++
 						}
 					}(u)
 				}
+				logger.Info("metric.background_tick",
+					"loop", "sync",
+					"users_processed", len(users),
+					"duration_ms", time.Since(tickStart).Milliseconds(),
+					"errors", syncErrors)
 			}
 		}
 	}()
@@ -204,13 +227,16 @@ func main() {
 		go func() {
 			defer wg.Done()
 
+			// Governing: ADR-0019 (structured metrics), SPEC observability REQ "BG-001", REQ "BG-002"
 			syncMetadataForUsers := func() {
+				tickStart := time.Now()
 				// Governing: SPEC graceful-shutdown REQ-CTX-003 (per-user goroutines use root ctx)
 				users, err := client.User.Query().All(ctx)
 				if err != nil {
 					logger.Error("failed to fetch users for metadata sync", "error", err)
 					return
 				}
+				metadataErrors := 0
 				for _, u := range users {
 					// Governing: SPEC graceful-shutdown REQ-WG-002 (wg.Add before spawn, defer wg.Done first)
 					wg.Add(1)
@@ -225,9 +251,15 @@ func main() {
 						}
 						if err := metadataSvc.SyncAll(ctx, user); err != nil {
 							logger.Error("metadata sync failed", "username", user.Username, "error", err)
+							metadataErrors++
 						}
 					}(u)
 				}
+				logger.Info("metric.background_tick",
+					"loop", "metadata",
+					"users_processed", len(users),
+					"duration_ms", time.Since(tickStart).Milliseconds(),
+					"errors", metadataErrors)
 			}
 
 			// Initial delay to let the app start up
@@ -255,6 +287,7 @@ func main() {
 		logger.Info("metadata enrichment disabled")
 	}
 
+	// Governing: ADR-0019 (structured metrics), SPEC observability REQ "BG-001", REQ "BG-002"
 	// Background Playlist Sync Loop (for syncing playlists to Navidrome)
 	playlistSyncInterval, err := time.ParseDuration(cfg.PlaylistSync.SyncInterval)
 	if err != nil {
@@ -280,12 +313,14 @@ func main() {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
+				tickStart := time.Now()
 				// Governing: SPEC graceful-shutdown REQ-CTX-003 (per-user goroutines use root ctx)
 				users, err := client.User.Query().All(ctx)
 				if err != nil {
 					logger.Error("failed to fetch users for playlist sync", "error", err)
 					continue
 				}
+				plSyncErrors := 0
 				for _, u := range users {
 					// Governing: SPEC graceful-shutdown REQ-WG-002 (wg.Add before spawn, defer wg.Done first)
 					wg.Add(1)
@@ -300,9 +335,15 @@ func main() {
 						}
 						if err := playlistSyncSvc.SyncAllEnabledPlaylists(ctx, user.ID); err != nil {
 							logger.Error("playlist sync failed", "username", user.Username, "error", err)
+							plSyncErrors++
 						}
 					}(u)
 				}
+				logger.Info("metric.background_tick",
+					"loop", "playlist_sync",
+					"users_processed", len(users),
+					"duration_ms", time.Since(tickStart).Milliseconds(),
+					"errors", plSyncErrors)
 			}
 		}
 	}()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,7 +45,11 @@ type VibesConfig struct {
 	MinMatchConfidence float64 `mapstructure:"min_match_confidence"`
 }
 
+// Governing: ADR-0019 (structured metrics), ADR-0010 (slog), SPEC observability REQ "FMT-001", REQ "FMT-002"
 type Config struct {
+	Log struct {
+		Format string `mapstructure:"format"` // Log format: "json" or "text" (default: "text")
+	} `mapstructure:"log"`
 	Security struct {
 		EncryptionKey string `mapstructure:"encryption_key"` // 32-byte hex key for AES-256 encryption
 		SecureCookies bool   `mapstructure:"secure_cookies"` // Set Secure flag on cookies (requires HTTPS)
@@ -205,6 +209,7 @@ func Load() (*Config, error) {
 	v.AutomaticEnv()
 
 	// Defaults
+	v.SetDefault("log.format", "text")            // Log format: "json" or "text"
 	v.SetDefault("security.encryption_key", "")   // Must be set via environment variable
 	v.SetDefault("security.secure_cookies", true) // Secure cookies by default (requires HTTPS)
 	v.SetDefault("security.jwt_secret", "")       // Must be set via environment variable

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -28,6 +28,21 @@ func TestLoadDefaults(t *testing.T) {
 	assert.Equal(t, "light,dark,cupcake", cfg.Theme.Available)
 	assert.Equal(t, "dark", cfg.Theme.Default)
 	assert.Equal(t, []string{"light", "dark", "cupcake"}, cfg.AvailableThemes())
+	assert.Equal(t, "text", cfg.Log.Format)
+}
+
+func TestLogFormatConfig(t *testing.T) {
+	t.Setenv("SPOTTER_NAVIDROME_BASE_URL", "http://localhost:4533")
+	t.Setenv("SPOTTER_OPENAI_API_KEY", "sk-test-key")
+	t.Setenv("SPOTTER_LIDARR_BASE_URL", "http://localhost:8686")
+	t.Setenv("SPOTTER_LIDARR_API_KEY", "test-api-key")
+	t.Setenv("SPOTTER_SECURITY_ENCRYPTION_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	t.Setenv("SPOTTER_SECURITY_JWT_SECRET", "test-jwt-secret-at-least-32-chars")
+	t.Setenv("SPOTTER_LOG_FORMAT", "json")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.Equal(t, "json", cfg.Log.Format)
 }
 
 func TestLoadEnvOverrides(t *testing.T) {

--- a/internal/middleware/logging.go
+++ b/internal/middleware/logging.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 )
 
+// Governing: ADR-0019 (structured metrics), ADR-0010 (slog), SPEC observability REQ "REQ-001", REQ "REQ-002"
 func Logger(logger *slog.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -15,12 +16,13 @@ func Logger(logger *slog.Logger) func(http.Handler) http.Handler {
 
 			t1 := time.Now()
 			defer func() {
-				logger.Info("request completed",
+				logger.Info("metric.request",
 					slog.String("method", r.Method),
 					slog.String("path", r.URL.Path),
 					slog.Int("status", ww.Status()),
 					slog.String("remote_ip", r.RemoteAddr),
 					slog.Duration("latency", time.Since(t1)),
+					slog.Int64("duration_ms", time.Since(t1).Milliseconds()),
 					slog.String("request_id", middleware.GetReqID(r.Context())),
 				)
 			}()

--- a/internal/services/metadata.go
+++ b/internal/services/metadata.go
@@ -1,4 +1,5 @@
 // Governing: ADR-0008 (OpenAI), ADR-0004 (Ent ORM), SPEC metadata-enrichment-pipeline
+
 package services
 
 import (
@@ -521,9 +522,10 @@ func (s *MetadataService) getActiveEnrichers(ctx context.Context, u *ent.User) (
 	return active, nil
 }
 
+// Governing: ADR-0019 (structured metrics), SPEC observability REQ "BG-004"
 // Governing: SPEC graceful-shutdown REQ-REC-003 (metadata enrichment tracks per-entity state via LastEnrichedAt)
-// EnrichArtists runs enrichment on all artists that need it.
 func (s *MetadataService) EnrichArtists(ctx context.Context, u *ent.User) (int, error) {
+	enrichStart := time.Now()
 	s.Logger.Info("enriching artists", "username", u.Username)
 
 	enricherList, err := s.getActiveEnrichers(ctx, u)
@@ -580,6 +582,20 @@ func (s *MetadataService) EnrichArtists(ctx context.Context, u *ent.User) (int, 
 		}
 		enrichedCount++
 	}
+
+	enrichSuccess := true
+	var enrichErr string
+	if enrichedCount < len(artists) && len(artists) > 0 {
+		enrichSuccess = false
+		enrichErr = fmt.Sprintf("%d of %d artists failed enrichment", len(artists)-enrichedCount, len(artists))
+	}
+	s.Logger.Info("metric.enricher",
+		"enricher", "artists",
+		"entity_type", "artist",
+		"entities_processed", len(artists),
+		"duration_ms", time.Since(enrichStart).Milliseconds(),
+		"success", enrichSuccess,
+		"error", enrichErr)
 
 	return enrichedCount, nil
 }
@@ -759,8 +775,10 @@ func (s *MetadataService) saveArtistImages(ctx context.Context, art *ent.Artist,
 	return nil
 }
 
+// Governing: ADR-0019 (structured metrics), SPEC observability REQ "BG-004"
 // EnrichAlbums runs enrichment on all albums that need it.
 func (s *MetadataService) EnrichAlbums(ctx context.Context, u *ent.User) (int, error) {
+	enrichStart := time.Now()
 	s.Logger.Info("enriching albums", "username", u.Username)
 
 	enricherList, err := s.getActiveEnrichers(ctx, u)
@@ -814,6 +832,20 @@ func (s *MetadataService) EnrichAlbums(ctx context.Context, u *ent.User) (int, e
 		}
 		enrichedCount++
 	}
+
+	enrichSuccess := true
+	var enrichErr string
+	if enrichedCount < len(albums) && len(albums) > 0 {
+		enrichSuccess = false
+		enrichErr = fmt.Sprintf("%d of %d albums failed enrichment", len(albums)-enrichedCount, len(albums))
+	}
+	s.Logger.Info("metric.enricher",
+		"enricher", "albums",
+		"entity_type", "album",
+		"entities_processed", len(albums),
+		"duration_ms", time.Since(enrichStart).Milliseconds(),
+		"success", enrichSuccess,
+		"error", enrichErr)
 
 	return enrichedCount, nil
 }
@@ -1127,8 +1159,10 @@ func (s *MetadataService) saveAlbumImages(ctx context.Context, alb *ent.Album, i
 	return nil
 }
 
+// Governing: ADR-0019 (structured metrics), SPEC observability REQ "BG-004"
 // EnrichTracks runs enrichment on all tracks that need it.
 func (s *MetadataService) EnrichTracks(ctx context.Context, u *ent.User) (int, error) {
+	enrichStart := time.Now()
 	s.Logger.Info("enriching tracks", "username", u.Username)
 
 	enricherList, err := s.getActiveEnrichers(ctx, u)
@@ -1181,6 +1215,20 @@ func (s *MetadataService) EnrichTracks(ctx context.Context, u *ent.User) (int, e
 		}
 		enrichedCount++
 	}
+
+	enrichSuccess := true
+	var enrichErr string
+	if enrichedCount < len(userTracks) && len(userTracks) > 0 {
+		enrichSuccess = false
+		enrichErr = fmt.Sprintf("%d of %d tracks failed enrichment", len(userTracks)-enrichedCount, len(userTracks))
+	}
+	s.Logger.Info("metric.enricher",
+		"enricher", "tracks",
+		"entity_type", "track",
+		"entities_processed", len(userTracks),
+		"duration_ms", time.Since(enrichStart).Milliseconds(),
+		"success", enrichSuccess,
+		"error", enrichErr)
 
 	return enrichedCount, nil
 }

--- a/internal/services/similar_artists.go
+++ b/internal/services/similar_artists.go
@@ -1,4 +1,5 @@
 // Governing: ADR-0007 (event bus), ADR-0008 (OpenAI), ADR-0004 (Ent ORM), SPEC similar-artists-discovery
+
 package services
 
 import (
@@ -174,11 +175,30 @@ func (s *SimilarArtistsService) FindSimilarArtists(ctx context.Context, userID i
 		return fmt.Errorf("failed to render prompt: %w", err)
 	}
 
+	// Governing: ADR-0019 (structured metrics), SPEC observability REQ "LLM-001", REQ "LLM-002", REQ "LLM-003"
 	// Call OpenAI
+	model := s.config.GetVibesModel()
+	llmStart := time.Now()
 	response, err := s.callOpenAI(ctx, prompt)
+	llmDuration := time.Since(llmStart).Milliseconds()
 	if err != nil {
+		s.logger.Info("metric.llm",
+			"model", model,
+			"operation", "similar_artists",
+			"tokens_used", 0,
+			"duration_ms", llmDuration,
+			"success", false,
+			"error", err.Error())
 		return fmt.Errorf("failed to call OpenAI: %w", err)
 	}
+
+	s.logger.Info("metric.llm",
+		"model", model,
+		"operation", "similar_artists",
+		"tokens_used", 0,
+		"duration_ms", llmDuration,
+		"success", true,
+		"error", "")
 
 	// Parse response
 	var aiResponse SimilarArtistResponse

--- a/internal/services/sync.go
+++ b/internal/services/sync.go
@@ -45,23 +45,48 @@ func (s *Syncer) Register(factory providers.Factory) {
 	s.Factories = append(s.Factories, factory)
 }
 
+// Governing: ADR-0019 (structured metrics), SPEC observability REQ "BG-003"
 // Sync performs a full synchronization (history and playlists) for the user.
 func (s *Syncer) Sync(ctx context.Context, u *ent.User) error {
 	s.Logger.Info("starting full sync", "username", u.Username)
+	syncStart := time.Now()
 
 	refreshedUser, activeProviders, err := s.getActiveProviders(ctx, u)
 	if err != nil {
 		return err
 	}
 
+	var listensSynced, playlistsSynced int
+	syncSuccess := true
+	var syncErr string
+
 	// 1. History
-	if err := s.syncHistory(ctx, refreshedUser, activeProviders); err != nil {
-		s.Logger.Error("failed to sync history", "username", refreshedUser.Username, "error", err)
+	var histErr error
+	listensSynced, histErr = s.syncHistory(ctx, refreshedUser, activeProviders)
+	if histErr != nil {
+		s.Logger.Error("failed to sync history", "username", refreshedUser.Username, "error", histErr)
+		syncSuccess = false
+		syncErr = histErr.Error()
 	}
 
 	// 2. Playlists
-	if err := s.syncPlaylists(ctx, refreshedUser, activeProviders); err != nil {
-		s.Logger.Error("failed to sync playlists", "username", refreshedUser.Username, "error", err)
+	var plErr error
+	playlistsSynced, plErr = s.syncPlaylists(ctx, refreshedUser, activeProviders)
+	if plErr != nil {
+		s.Logger.Error("failed to sync playlists", "username", refreshedUser.Username, "error", plErr)
+		syncSuccess = false
+		syncErr = plErr.Error()
+	}
+
+	// Emit metric.sync for each active provider
+	for _, p := range activeProviders {
+		s.Logger.Info("metric.sync",
+			"provider", string(p.Type()),
+			"listens_synced", listensSynced,
+			"playlists_synced", playlistsSynced,
+			"duration_ms", time.Since(syncStart).Milliseconds(),
+			"success", syncSuccess,
+			"error", syncErr)
 	}
 
 	s.Logger.Info("full sync completed", "username", refreshedUser.Username)
@@ -91,12 +116,12 @@ func (s *Syncer) SyncProvider(ctx context.Context, u *ent.User, providerType pro
 	}
 
 	// 1. History
-	if err := s.syncHistory(ctx, refreshedUser, targetProviders); err != nil {
+	if _, err := s.syncHistory(ctx, refreshedUser, targetProviders); err != nil {
 		s.Logger.Error("failed to sync history", "username", refreshedUser.Username, "provider", providerType, "error", err)
 	}
 
 	// 2. Playlists
-	if err := s.syncPlaylists(ctx, refreshedUser, targetProviders); err != nil {
+	if _, err := s.syncPlaylists(ctx, refreshedUser, targetProviders); err != nil {
 		s.Logger.Error("failed to sync playlists", "username", refreshedUser.Username, "provider", providerType, "error", err)
 	}
 
@@ -110,7 +135,8 @@ func (s *Syncer) SyncRecentListens(ctx context.Context, u *ent.User) error {
 	if err != nil {
 		return err
 	}
-	return s.syncHistory(ctx, refreshedUser, activeProviders)
+	_, err = s.syncHistory(ctx, refreshedUser, activeProviders)
+	return err
 }
 
 // SyncPlaylists pulls playlists from all registered providers.
@@ -119,7 +145,8 @@ func (s *Syncer) SyncPlaylists(ctx context.Context, u *ent.User) error {
 	if err != nil {
 		return err
 	}
-	return s.syncPlaylists(ctx, refreshedUser, activeProviders)
+	_, err = s.syncPlaylists(ctx, refreshedUser, activeProviders)
+	return err
 }
 
 // getActiveProviders returns the refreshed user with all auth edges loaded and a list of active providers.
@@ -169,7 +196,8 @@ func (s *Syncer) logEvent(ctx context.Context, u *ent.User, eventType syncevent.
 	}
 }
 
-func (s *Syncer) syncHistory(ctx context.Context, u *ent.User, activeProviders []providers.Provider) error {
+func (s *Syncer) syncHistory(ctx context.Context, u *ent.User, activeProviders []providers.Provider) (int, error) {
+	allAdded := 0
 	for _, provider := range activeProviders {
 		// Check if provider supports history fetching
 		fetcher, ok := provider.(providers.HistoryFetcher)
@@ -270,6 +298,7 @@ func (s *Syncer) syncHistory(ctx context.Context, u *ent.User, activeProviders [
 		// Governing: SPEC error-handling REQ-RECOVER-001, REQ-RECOVER-002
 		s.Backoff.RecordSuccess(backoffKey)
 
+		allAdded += totalAdded
 		if totalAdded > 0 {
 			s.Bus.Publish(u.ID, events.Event{
 				Type: events.EventTypeNotification,
@@ -298,10 +327,11 @@ func (s *Syncer) syncHistory(ctx context.Context, u *ent.User, activeProviders [
 			s.Logger.Warn("failed to update last_synced_at", "provider", provider.Type(), "error", err)
 		}
 	}
-	return nil
+	return allAdded, nil
 }
 
-func (s *Syncer) syncPlaylists(ctx context.Context, u *ent.User, activeProviders []providers.Provider) error {
+func (s *Syncer) syncPlaylists(ctx context.Context, u *ent.User, activeProviders []providers.Provider) (int, error) {
+	allAdded := 0
 	for _, provider := range activeProviders {
 		manager, ok := provider.(providers.PlaylistManager)
 		if !ok {
@@ -364,6 +394,7 @@ func (s *Syncer) syncPlaylists(ctx context.Context, u *ent.User, activeProviders
 			if err != nil {
 				s.Logger.Error("failed to persist playlists", "error", err)
 			}
+			allAdded += added
 
 			if added > 0 {
 				s.Bus.Publish(u.ID, events.Event{
@@ -391,7 +422,7 @@ func (s *Syncer) syncPlaylists(ctx context.Context, u *ent.User, activeProviders
 			s.Logger.Warn("failed to update last_synced_at", "provider", provider.Type(), "error", err)
 		}
 	}
-	return nil
+	return allAdded, nil
 }
 
 // publishFatalNotification publishes a user-visible notification for fatal provider errors.

--- a/internal/services/track_matcher.go
+++ b/internal/services/track_matcher.go
@@ -128,8 +128,10 @@ func (m *TrackMatcher) MatchTracks(ctx context.Context, userID int, tracks []pro
 		MatchMethodFuzzy: 0,
 	}
 
+	// Governing: ADR-0019 (structured metrics), SPEC observability REQ "MATCH-001", REQ "MATCH-002", REQ "MATCH-003"
 	// Match each source track
 	for i, sourceTrack := range tracks {
+		trackMatchStart := time.Now()
 		result := MatchResult{
 			SourceTrack:     sourceTrack,
 			MatchConfidence: 0.0,
@@ -152,6 +154,12 @@ func (m *TrackMatcher) MatchTracks(ctx context.Context, userID int, tracks []pro
 						"source_title", sourceTrack.Name,
 						"isrc", sourceTrack.ISRC,
 						"navidrome_id", *matchedTrack.NavidromeID)
+					// REQ "MATCH-002": emit metric for the successful strategy only
+					m.Logger.Info("metric.track_match",
+						"strategy", "isrc",
+						"matched", true,
+						"confidence", 1.0,
+						"duration_ms", time.Since(trackMatchStart).Milliseconds())
 					continue
 				}
 			}
@@ -171,6 +179,12 @@ func (m *TrackMatcher) MatchTracks(ctx context.Context, userID int, tracks []pro
 					"source_artist", sourceTrack.Artist,
 					"source_title", sourceTrack.Name,
 					"navidrome_id", *matchedTrack.NavidromeID)
+				// REQ "MATCH-002": emit metric for the successful strategy only
+				m.Logger.Info("metric.track_match",
+					"strategy", "exact",
+					"matched", true,
+					"confidence", 1.0,
+					"duration_ms", time.Since(trackMatchStart).Milliseconds())
 				continue
 			}
 		}
@@ -196,6 +210,12 @@ func (m *TrackMatcher) MatchTracks(ctx context.Context, userID int, tracks []pro
 					"matched_title", bestMatch.Name,
 					"confidence", confidence,
 					"navidrome_id", *bestMatch.NavidromeID)
+				// REQ "MATCH-002": emit metric for the successful strategy only
+				m.Logger.Info("metric.track_match",
+					"strategy", "fuzzy",
+					"matched", true,
+					"confidence", confidence,
+					"duration_ms", time.Since(trackMatchStart).Milliseconds())
 			}
 		} else {
 			matchStats[MatchMethodNone]++
@@ -205,6 +225,12 @@ func (m *TrackMatcher) MatchTracks(ctx context.Context, userID int, tracks []pro
 				"source_title", sourceTrack.Name,
 				"best_confidence", confidence,
 				"min_required", m.MinMatchConfidence)
+			// REQ "MATCH-003": all strategies failed, emit strategy="fuzzy", matched=false, confidence=0.0
+			m.Logger.Info("metric.track_match",
+				"strategy", "fuzzy",
+				"matched", false,
+				"confidence", 0.0,
+				"duration_ms", time.Since(trackMatchStart).Milliseconds())
 		}
 
 		results[i] = result

--- a/internal/vibes/enhancer.go
+++ b/internal/vibes/enhancer.go
@@ -169,13 +169,31 @@ func (e *PlaylistEnhancer) EnhancePlaylist(ctx context.Context, req *Enhancement
 
 	e.logger.Debug("generated prompt", "prompt_length", len(prompt))
 
+	// Governing: ADR-0019 (structured metrics), SPEC observability REQ "LLM-001", REQ "LLM-002", REQ "LLM-003"
 	// Call the AI
 	model := e.config.GetVibesModel()
+	llmStart := time.Now()
 	response, tokensUsed, err := e.callOpenAI(ctx, prompt)
+	llmDuration := time.Since(llmStart).Milliseconds()
 	if err != nil {
+		e.logger.Info("metric.llm",
+			"model", model,
+			"operation", "playlist_enhance",
+			"tokens_used", 0,
+			"duration_ms", llmDuration,
+			"success", false,
+			"error", err.Error())
 		e.publishError(req.UserID, req.PlaylistID, "AI service error: "+err.Error())
 		return nil, fmt.Errorf("AI call failed: %w", err)
 	}
+
+	e.logger.Info("metric.llm",
+		"model", model,
+		"operation", "playlist_enhance",
+		"tokens_used", tokensUsed,
+		"duration_ms", llmDuration,
+		"success", true,
+		"error", "")
 
 	e.logger.Info("AI enhancement complete",
 		"model", model,

--- a/internal/vibes/generator.go
+++ b/internal/vibes/generator.go
@@ -1,3 +1,4 @@
+// Governing: ADR-0008 (OpenAI API / LiteLLM backend), ADR-0007 (event bus), SPEC vibes-ai-mixtape-engine
 package vibes
 
 import (
@@ -189,8 +190,11 @@ func (g *MixtapeGenerator) GenerateMixtape(ctx context.Context, req *GenerationR
 
 	// Call the AI
 	// Governing: SPEC vibes-ai-mixtape-engine REQ-VIBES-030 — timeout enforced via httpClient
+	// Governing: ADR-0019 (structured metrics), SPEC observability REQ "LLM-001", REQ "LLM-002", REQ "LLM-003"
 	model := g.config.GetVibesModel()
+	llmStart := time.Now()
 	response, tokensUsed, err := g.callOpenAI(ctx, prompt)
+	llmDuration := time.Since(llmStart).Milliseconds()
 	if err != nil {
 		// Governing: SPEC vibes-ai-mixtape-engine REQ-VIBES-032 — structured error logging
 		g.logger.Error("AI call failed during mixtape generation",
@@ -198,9 +202,24 @@ func (g *MixtapeGenerator) GenerateMixtape(ctx context.Context, req *GenerationR
 			"dj_id", req.DJ.ID,
 			"mixtape_id", req.Mixtape.ID,
 			"error", err)
+		g.logger.Info("metric.llm",
+			"model", model,
+			"operation", "mixtape_generate",
+			"tokens_used", 0,
+			"duration_ms", llmDuration,
+			"success", false,
+			"error", err.Error())
 		g.publishError(req.UserID, "AI service error: "+err.Error())
 		return nil, fmt.Errorf("AI call failed: %w", err)
 	}
+
+	g.logger.Info("metric.llm",
+		"model", model,
+		"operation", "mixtape_generate",
+		"tokens_used", tokensUsed,
+		"duration_ms", llmDuration,
+		"success", true,
+		"error", "")
 
 	g.logger.Info("AI generation complete",
 		"model", model,


### PR DESCRIPTION
## Summary

- **Log format config (#73):** Add `SPOTTER_LOG_FORMAT` env var (`json`/`text`, defaults to text). Invalid values silently default to text. Startup log confirms format and level.
- **Background job instrumentation (#76):** Emit `metric.background_tick` at Info level for each sync/metadata/playlist_sync loop tick with `loop`, `users_processed`, `duration_ms`, `errors`. Emit `metric.sync` after per-user sync. Emit `metric.enricher` after artist/album/track enrichment batches.
- **HTTP + LLM instrumentation (#78):** Update request middleware to `metric.request` with `duration_ms`. Add `metric.llm` events to mixtape generation (`mixtape_generate`), playlist enhancement (`playlist_enhance`), and similar artists (`similar_artists`).
- **Track matching instrumentation (#81):** Emit `metric.track_match` per track with `strategy`, `matched`, `confidence`, `duration_ms`. Only the successful or final-failing strategy emits (MATCH-002). Failed matches emit `strategy=fuzzy, matched=false, confidence=0.0` (MATCH-003).

All metric events use the `metric.` prefix convention with `_ms` suffix for durations and `success`/`error` keys per the observability spec.

Closes #73
Closes #76
Closes #78
Closes #81

Part of the observability spec. Governed by ADR-0019 (structured metrics), ADR-0010 (slog).

## Test plan

- [x] All existing tests pass (`go test ./internal/config/... ./internal/services/... ./internal/vibes/...`)
- [x] New config test validates `SPOTTER_LOG_FORMAT=json` is respected
- [ ] Manual: Start server with `SPOTTER_LOG_FORMAT=json`, verify JSON output
- [ ] Manual: Start server with `SPOTTER_LOG_FORMAT=invalid`, verify text output (no crash)
- [ ] Manual: Trigger a sync and verify `metric.background_tick` and `metric.sync` events appear
- [ ] Manual: Trigger metadata enrichment and verify `metric.enricher` events appear
- [ ] Manual: Make HTTP requests and verify `metric.request` events with `duration_ms`
- [ ] Manual: Generate a mixtape and verify `metric.llm` events appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)