### PR TITLE
Security: OAuth & session cookie hardening

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/spf13/viper"
@@ -45,6 +46,22 @@ type VibesConfig struct {
 	MinMatchConfidence float64 `mapstructure:"min_match_confidence"`
 }
 
+// LastFMConfig holds Last.fm API credentials and redirect URL.
+type LastFMConfig struct {
+	APIKey       string `mapstructure:"api_key"`
+	SharedSecret string `mapstructure:"shared_secret"`
+	RedirectURL  string `mapstructure:"redirect_url"`
+}
+
+// Governing: SPEC user-authentication REQ "Config LogValue Sanitization"
+// LogValue redacts sensitive fields when logging LastFMConfig via slog.
+func (c LastFMConfig) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("api_key", "[REDACTED]"),
+		slog.String("shared_secret", "[REDACTED]"),
+	)
+}
+
 // Governing: ADR-0019 (structured metrics), ADR-0010 (slog), SPEC observability REQ "FMT-001", REQ "FMT-002"
 type Config struct {
 	Log struct {
@@ -82,11 +99,7 @@ type Config struct {
 		ClientSecret string `mapstructure:"client_secret"`
 		RedirectURL  string `mapstructure:"redirect_url"`
 	} `mapstructure:"spotify"`
-	LastFM struct {
-		APIKey       string `mapstructure:"api_key"`
-		SharedSecret string `mapstructure:"shared_secret"`
-		RedirectURL  string `mapstructure:"redirect_url"`
-	} `mapstructure:"lastfm"`
+	LastFM LastFMConfig `mapstructure:"lastfm"`
 	OpenAI struct {
 		APIKey  string `mapstructure:"api_key"`  // OpenAI API key (required for AI enrichment)
 		BaseURL string `mapstructure:"base_url"` // Base URL for API (for LiteLLM or compatible proxies)

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -191,10 +191,20 @@ func (h *Handler) authenticateNavidrome(username, password string) error {
 
 	// Handle trailing slash in base URL
 	apiURL := fmt.Sprintf("%s/rest/ping.view?%s", baseURL, params.Encode())
-	// Simple check if base URL already has /rest
-	// But usually baseURL is just the host:port or host:port/navidrome
 
-	resp, err := http.Get(apiURL)
+	// Governing: SPEC user-authentication REQ "Sanitize Navidrome Auth Debug Logs"
+	// Log sanitized URL (strip password hash params t= and s=)
+	if sanitizedURL, err := url.Parse(apiURL); err == nil {
+		q := sanitizedURL.Query()
+		q.Del("t")
+		q.Del("s")
+		sanitizedURL.RawQuery = q.Encode()
+		h.Logger.Debug("authenticating against Navidrome", "url", sanitizedURL.String())
+	}
+
+	// Governing: SPEC user-authentication REQ "Auth HTTP Client Timeout"
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(apiURL)
 	if err != nil {
 		return err
 	}

--- a/internal/handlers/lastfm_auth.go
+++ b/internal/handlers/lastfm_auth.go
@@ -62,7 +62,8 @@ func (h *Handler) LastFMLogin(w http.ResponseWriter, r *http.Request) {
 		Value:    stateWithSession,
 		Path:     "/",
 		HttpOnly: true,
-		Secure:   r.TLS != nil,
+		// Governing: SPEC user-authentication REQ "OAuth Secure Cookie Flag"
+		Secure:   h.Config.Security.SecureCookies,
 		SameSite: http.SameSiteLaxMode,
 		Expires:  time.Now().Add(lastfmStateTTL),
 	})

--- a/internal/handlers/spotify_auth.go
+++ b/internal/handlers/spotify_auth.go
@@ -72,7 +72,8 @@ func (h *Handler) SpotifyLogin(w http.ResponseWriter, r *http.Request) {
 		Value:    state,
 		Path:     "/",
 		HttpOnly: true,
-		Secure:   r.TLS != nil,
+		// Governing: SPEC user-authentication REQ "OAuth Secure Cookie Flag"
+		Secure:   h.Config.Security.SecureCookies,
 		SameSite: http.SameSiteLaxMode,
 		Expires:  time.Now().Add(spotifyStateTTL),
 	})

--- a/internal/providers/lastfm/lastfm.go
+++ b/internal/providers/lastfm/lastfm.go
@@ -116,7 +116,8 @@ func (p *Provider) GetAuthURL(state string) string {
 
 // ExchangeCode exchanges the authorization token for a session key.
 func (p *Provider) ExchangeCode(ctx context.Context, code string) (*providers.AuthResult, error) {
-	p.logger.Info("exchanging code for session key", "code", code)
+	// Governing: SPEC user-authentication REQ "Suppress Last.fm Token from Logs"
+	p.logger.Debug("exchanging code for session key")
 
 	params := map[string]string{
 		"method":  "auth.getSession",


### PR DESCRIPTION
## Summary
- Fix OAuth state cookies in Spotify and Last.fm flows to use `config.Security.SecureCookies` instead of `r.TLS != nil`, matching the pattern already used for session cookies
- Sanitize Navidrome authentication debug logs by stripping password hash (`t=`) and salt (`s=`) query parameters from logged URLs
- Suppress Last.fm authorization token from INFO-level logs (moved to DEBUG, removed token value)
- Add `LogValue()` method to `LastFMConfig` to redact API key and shared secret in structured log output
- Add 10-second HTTP client timeout to `authenticateNavidrome` to prevent hanging requests

## Test plan
- [x] All existing tests pass (`make test`)
- [ ] Verify Spotify OAuth flow still works with secure cookie flag from config
- [ ] Verify Last.fm OAuth flow still works with secure cookie flag from config
- [ ] Verify Navidrome login works with HTTP client timeout
- [ ] Check logs to confirm no sensitive tokens/credentials leak at INFO level

Closes #89, closes #91, closes #93, closes #102, closes #105
Governing: SPEC user-authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)