### PR TITLE
Security: input validation, open redirect, and XSS prevention

### DIFF
--- a/internal/handlers/images.go
+++ b/internal/handlers/images.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -172,12 +173,22 @@ func (h *Handler) PlaylistImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Governing: SPEC user-authentication REQ "Input Validation"
+	// Validate URL scheme before redirect to prevent open redirect attacks (javascript:, data:, etc.)
+	parsed, err := url.Parse(p.ImageURL)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		h.Logger.Warn("blocked redirect to invalid image URL", "url", p.ImageURL)
+		http.Error(w, "invalid image URL", http.StatusBadRequest)
+		return
+	}
+
 	// Redirect to the external URL for playlists
 	http.Redirect(w, r, p.ImageURL, http.StatusTemporaryRedirect)
 }
 
 // serveImage serves an image from a local path
-// Governing: filepath.Abs + HasPrefix validates path stays within ./data to prevent traversal
+// Governing: SPEC user-authentication REQ "Input Validation"
+// filepath.Abs + HasPrefix validates path stays within ./data to prevent path traversal
 func (h *Handler) serveImage(w http.ResponseWriter, r *http.Request, localPath string) {
 	// Try to serve local file first
 	if localPath != "" {

--- a/internal/views/components/taginput.templ
+++ b/internal/views/components/taginput.templ
@@ -1,5 +1,7 @@
 package components
 
+import "encoding/json"
+
 type TagInputConfig struct {
 	// ID is the unique identifier for this input (used for form submission and JS targeting)
 	ID string
@@ -98,39 +100,29 @@ templ TagInput(cfg TagInputConfig) {
 	</div>
 }
 
+// Governing: SPEC user-authentication REQ "Input Validation"
+// Use encoding/json for tag values, suggestionsURL, and placeholder to prevent XSS via injection
 func tagInputData(cfg TagInputConfig) string {
-	// Build initial tags JSON
-	tagsJSON := "[]"
-	if len(cfg.InitialTags) > 0 {
-		tagsJSON = "["
-		for i, tag := range cfg.InitialTags {
-			if i > 0 {
-				tagsJSON += ","
-			}
-			// Escape single quotes in tag names
-			escapedTag := ""
-			for _, c := range tag {
-				if c == '\'' {
-					escapedTag += "\\'"
-				} else if c == '\\' {
-					escapedTag += "\\\\"
-				} else {
-					escapedTag += string(c)
-				}
-			}
-			tagsJSON += "'" + escapedTag + "'"
-		}
-		tagsJSON += "]"
+	tagsJSON, err := json.Marshal(cfg.InitialTags)
+	if err != nil {
+		tagsJSON = []byte("[]")
+	}
+	// Normalize nil to empty array
+	if cfg.InitialTags == nil {
+		tagsJSON = []byte("[]")
 	}
 
+	suggestionsURLJSON, _ := json.Marshal(cfg.SuggestionsURL)
+	placeholderJSON, _ := json.Marshal(cfg.Placeholder)
+
 	return `{
-		tags: ` + tagsJSON + `,
+		tags: ` + string(tagsJSON) + `,
 		query: '',
 		suggestions: [],
 		showSuggestions: false,
 		selectedIndex: -1,
-		suggestionsURL: '` + cfg.SuggestionsURL + `',
-		placeholderText: '` + cfg.Placeholder + `',
+		suggestionsURL: ` + string(suggestionsURLJSON) + `,
+		placeholderText: ` + string(placeholderJSON) + `,
 
 		get tagsString() {
 			return this.tags.join(', ');

--- a/internal/views/vibes/mixtape_show.templ
+++ b/internal/views/vibes/mixtape_show.templ
@@ -312,6 +312,8 @@ templ MixtapeShow(m *ent.Mixtape, tracks []*ent.Track, djs []*ent.DJ, cfg *confi
 				</div>
 			}
 			<!-- Generation Prompt (collapsible) -->
+			// Governing: SPEC user-authentication REQ "Input Validation"
+			// GenerationPrompt rendered via Templ string interpolation {}, which auto-escapes HTML
 			if m.GenerationPrompt != "" {
 				<div class="collapse collapse-arrow bg-base-100 shadow-xl mb-8">
 					<input type="checkbox"/>


### PR DESCRIPTION
## Summary
- Validate `ImageURL` scheme before redirect in `PlaylistImage` to block `javascript:`, `data:`, and other non-HTTP schemes (open redirect fix)
- Confirm playlist prompt and generation data use Templ's automatic HTML escaping (XSS prevention)
- Confirm `serveImage` has path traversal protection via `filepath.Abs` + `HasPrefix` base directory check
- Replace fragile manual JS string escaping in `tagInputData` with `encoding/json.Marshal` for tags, suggestionsURL, and placeholder

## Test plan
- [x] All existing tests pass (`make test`)
- [ ] Verify `PlaylistImage` returns HTTP 400 for `javascript:alert(1)` image URLs
- [ ] Verify `PlaylistImage` allows valid `https://` image URLs
- [ ] Verify tag input component renders correctly with special characters in tags
- [ ] Verify generation prompt display is properly escaped in mixtape show view

Closes #90, Closes #92, Closes #100, Closes #123
Governing: SPEC user-authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)