### PR TITLE
Bug: fix goroutine context safety and template render double-write

### DIFF
--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"time"
 
+	"bytes"
+
 	"spotter/ent"
 	"spotter/internal/auth"
 	"spotter/internal/config"
@@ -65,12 +67,16 @@ func New(client *ent.Client, cfg *config.Config, logger *slog.Logger, encryptor 
 	}
 }
 
+// Governing: SPEC graceful-shutdown REQ "prevent double-write on template render error"
 func (h *Handler) Render(w http.ResponseWriter, r *http.Request, component templ.Component) {
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := component.Render(r.Context(), w); err != nil {
+	var buf bytes.Buffer
+	if err := component.Render(r.Context(), &buf); err != nil {
 		h.Logger.Error("failed to render component", "error", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
 	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = buf.WriteTo(w)
 }
 
 // Governing: SPEC user-authentication REQ "MIDDLEWARE-005"

--- a/internal/handlers/preferences.go
+++ b/internal/handlers/preferences.go
@@ -165,6 +165,7 @@ func (h *Handler) DisconnectLastFM(w http.ResponseWriter, r *http.Request) {
 }
 
 // SyncNavidrome triggers a sync for Navidrome data
+// Governing: SPEC graceful-shutdown REQ "background goroutines must not capture *ent.User pointer"
 func (h *Handler) SyncNavidrome(w http.ResponseWriter, r *http.Request) {
 	u := h.GetUser(r.Context())
 	if u == nil {
@@ -181,8 +182,15 @@ func (h *Handler) SyncNavidrome(w http.ResponseWriter, r *http.Request) {
 		},
 	})
 
+	userID := u.ID
 	go func() {
-		if err := h.Syncer.SyncProvider(context.Background(), u, providers.TypeNavidrome); err != nil {
+		ctx := context.Background()
+		freshUser, err := h.Client.User.Get(ctx, userID)
+		if err != nil {
+			h.Logger.Error("failed to fetch user for navidrome sync", "error", err)
+			return
+		}
+		if err := h.Syncer.SyncProvider(ctx, freshUser, providers.TypeNavidrome); err != nil {
 			h.Logger.Error("failed to sync navidrome", "error", err)
 		}
 	}()
@@ -245,8 +253,15 @@ func (h *Handler) RebuildNavidrome(w http.ResponseWriter, r *http.Request) {
 		},
 	})
 
+	userID := u.ID
 	go func() {
-		if err := h.Syncer.SyncProvider(context.Background(), u, providers.TypeNavidrome); err != nil {
+		ctx := context.Background()
+		freshUser, err := h.Client.User.Get(ctx, userID)
+		if err != nil {
+			h.Logger.Error("failed to fetch user for navidrome rebuild sync", "error", err)
+			return
+		}
+		if err := h.Syncer.SyncProvider(ctx, freshUser, providers.TypeNavidrome); err != nil {
 			h.Logger.Error("failed to sync navidrome after rebuild", "error", err)
 		}
 	}()
@@ -255,6 +270,7 @@ func (h *Handler) RebuildNavidrome(w http.ResponseWriter, r *http.Request) {
 }
 
 // SyncSpotify triggers a sync for Spotify data
+// Governing: SPEC graceful-shutdown REQ "background goroutines must not capture *ent.User pointer"
 func (h *Handler) SyncSpotify(w http.ResponseWriter, r *http.Request) {
 	u := h.GetUser(r.Context())
 	if u == nil {
@@ -271,8 +287,15 @@ func (h *Handler) SyncSpotify(w http.ResponseWriter, r *http.Request) {
 		},
 	})
 
+	userID := u.ID
 	go func() {
-		if err := h.Syncer.SyncProvider(context.Background(), u, providers.TypeSpotify); err != nil {
+		ctx := context.Background()
+		freshUser, err := h.Client.User.Get(ctx, userID)
+		if err != nil {
+			h.Logger.Error("failed to fetch user for spotify sync", "error", err)
+			return
+		}
+		if err := h.Syncer.SyncProvider(ctx, freshUser, providers.TypeSpotify); err != nil {
 			h.Logger.Error("failed to sync spotify", "error", err)
 		}
 	}()
@@ -335,8 +358,15 @@ func (h *Handler) RebuildSpotify(w http.ResponseWriter, r *http.Request) {
 		},
 	})
 
+	userID := u.ID
 	go func() {
-		if err := h.Syncer.SyncProvider(context.Background(), u, providers.TypeSpotify); err != nil {
+		ctx := context.Background()
+		freshUser, err := h.Client.User.Get(ctx, userID)
+		if err != nil {
+			h.Logger.Error("failed to fetch user for spotify rebuild sync", "error", err)
+			return
+		}
+		if err := h.Syncer.SyncProvider(ctx, freshUser, providers.TypeSpotify); err != nil {
 			h.Logger.Error("failed to sync spotify after rebuild", "error", err)
 		}
 	}()
@@ -345,6 +375,7 @@ func (h *Handler) RebuildSpotify(w http.ResponseWriter, r *http.Request) {
 }
 
 // SyncLastFM triggers a sync for Last.fm data
+// Governing: SPEC graceful-shutdown REQ "background goroutines must not capture *ent.User pointer"
 func (h *Handler) SyncLastFM(w http.ResponseWriter, r *http.Request) {
 	u := h.GetUser(r.Context())
 	if u == nil {
@@ -361,8 +392,15 @@ func (h *Handler) SyncLastFM(w http.ResponseWriter, r *http.Request) {
 		},
 	})
 
+	userID := u.ID
 	go func() {
-		if err := h.Syncer.SyncProvider(context.Background(), u, providers.TypeLastFM); err != nil {
+		ctx := context.Background()
+		freshUser, err := h.Client.User.Get(ctx, userID)
+		if err != nil {
+			h.Logger.Error("failed to fetch user for lastfm sync", "error", err)
+			return
+		}
+		if err := h.Syncer.SyncProvider(ctx, freshUser, providers.TypeLastFM); err != nil {
 			h.Logger.Error("failed to sync lastfm", "error", err)
 		}
 	}()
@@ -412,8 +450,15 @@ func (h *Handler) RebuildLastFM(w http.ResponseWriter, r *http.Request) {
 		},
 	})
 
+	userID := u.ID
 	go func() {
-		if err := h.Syncer.SyncProvider(context.Background(), u, providers.TypeLastFM); err != nil {
+		ctx := context.Background()
+		freshUser, err := h.Client.User.Get(ctx, userID)
+		if err != nil {
+			h.Logger.Error("failed to fetch user for lastfm rebuild sync", "error", err)
+			return
+		}
+		if err := h.Syncer.SyncProvider(ctx, freshUser, providers.TypeLastFM); err != nil {
 			h.Logger.Error("failed to sync lastfm after rebuild", "error", err)
 		}
 	}()
@@ -648,6 +693,7 @@ func (h *Handler) getTasksWithLastRun(ctx context.Context, u *ent.User) []types.
 }
 
 // TaskSyncListens triggers a sync of all listens
+// Governing: SPEC graceful-shutdown REQ "background goroutines must not capture *ent.User pointer"
 func (h *Handler) TaskSyncListens(w http.ResponseWriter, r *http.Request) {
 	u := h.GetUser(r.Context())
 	if u == nil {
@@ -664,8 +710,15 @@ func (h *Handler) TaskSyncListens(w http.ResponseWriter, r *http.Request) {
 		},
 	})
 
+	userID := u.ID
 	go func() {
-		if err := h.Syncer.SyncRecentListens(context.Background(), u); err != nil {
+		ctx := context.Background()
+		freshUser, err := h.Client.User.Get(ctx, userID)
+		if err != nil {
+			h.Logger.Error("failed to fetch user for listen sync", "error", err)
+			return
+		}
+		if err := h.Syncer.SyncRecentListens(ctx, freshUser); err != nil {
 			h.Logger.Error("failed to sync listens", "error", err)
 		}
 	}()
@@ -674,6 +727,7 @@ func (h *Handler) TaskSyncListens(w http.ResponseWriter, r *http.Request) {
 }
 
 // TaskSyncPlaylists triggers a sync of all playlists
+// Governing: SPEC graceful-shutdown REQ "background goroutines must not capture *ent.User pointer"
 func (h *Handler) TaskSyncPlaylists(w http.ResponseWriter, r *http.Request) {
 	u := h.GetUser(r.Context())
 	if u == nil {
@@ -690,8 +744,15 @@ func (h *Handler) TaskSyncPlaylists(w http.ResponseWriter, r *http.Request) {
 		},
 	})
 
+	userID := u.ID
 	go func() {
-		if err := h.Syncer.SyncPlaylists(context.Background(), u); err != nil {
+		ctx := context.Background()
+		freshUser, err := h.Client.User.Get(ctx, userID)
+		if err != nil {
+			h.Logger.Error("failed to fetch user for playlist sync", "error", err)
+			return
+		}
+		if err := h.Syncer.SyncPlaylists(ctx, freshUser); err != nil {
 			h.Logger.Error("failed to sync playlists", "error", err)
 		}
 	}()
@@ -729,8 +790,15 @@ func (h *Handler) TaskEnrichMetadata(w http.ResponseWriter, r *http.Request) {
 		},
 	})
 
+	userID := u.ID
 	go func() {
-		if err := h.MetadataSvc.SyncAll(context.Background(), u); err != nil {
+		ctx := context.Background()
+		freshUser, err := h.Client.User.Get(ctx, userID)
+		if err != nil {
+			h.Logger.Error("failed to fetch user for metadata enrichment", "error", err)
+			return
+		}
+		if err := h.MetadataSvc.SyncAll(ctx, freshUser); err != nil {
 			h.Logger.Error("failed to run metadata enrichment", "error", err)
 		}
 	}()
@@ -768,11 +836,18 @@ func (h *Handler) TaskSyncArtistImages(w http.ResponseWriter, r *http.Request) {
 		},
 	})
 
+	userID := u.ID
 	go func() {
-		count, err := h.MetadataSvc.SyncAllArtistImages(context.Background(), u)
+		ctx := context.Background()
+		freshUser, err := h.Client.User.Get(ctx, userID)
+		if err != nil {
+			h.Logger.Error("failed to fetch user for artist image sync", "error", err)
+			return
+		}
+		count, err := h.MetadataSvc.SyncAllArtistImages(ctx, freshUser)
 		if err != nil {
 			h.Logger.Error("failed to sync artist images", "error", err)
-			h.Bus.Publish(u.ID, events.Event{
+			h.Bus.Publish(userID, events.Event{
 				Type: events.EventTypeNotification,
 				Payload: events.NotificationPayload{
 					Title:    "Sync Failed",
@@ -782,7 +857,7 @@ func (h *Handler) TaskSyncArtistImages(w http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
-		h.Bus.Publish(u.ID, events.Event{
+		h.Bus.Publish(userID, events.Event{
 			Type: events.EventTypeNotification,
 			Payload: events.NotificationPayload{
 				Title:    "Sync Complete",
@@ -825,11 +900,18 @@ func (h *Handler) TaskSyncAlbumImages(w http.ResponseWriter, r *http.Request) {
 		},
 	})
 
+	userID := u.ID
 	go func() {
-		count, err := h.MetadataSvc.SyncAllAlbumImages(context.Background(), u)
+		ctx := context.Background()
+		freshUser, err := h.Client.User.Get(ctx, userID)
+		if err != nil {
+			h.Logger.Error("failed to fetch user for album image sync", "error", err)
+			return
+		}
+		count, err := h.MetadataSvc.SyncAllAlbumImages(ctx, freshUser)
 		if err != nil {
 			h.Logger.Error("failed to sync album images", "error", err)
-			h.Bus.Publish(u.ID, events.Event{
+			h.Bus.Publish(userID, events.Event{
 				Type: events.EventTypeNotification,
 				Payload: events.NotificationPayload{
 					Title:    "Sync Failed",
@@ -839,7 +921,7 @@ func (h *Handler) TaskSyncAlbumImages(w http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
-		h.Bus.Publish(u.ID, events.Event{
+		h.Bus.Publish(userID, events.Event{
 			Type: events.EventTypeNotification,
 			Payload: events.NotificationPayload{
 				Title:    "Sync Complete",
@@ -952,14 +1034,21 @@ func (h *Handler) TaskResetData(w http.ResponseWriter, r *http.Request) {
 	})
 
 	// Re-sync everything in the background
+	// Governing: SPEC graceful-shutdown REQ "background goroutines must not capture *ent.User pointer"
+	userID := u.ID
 	go func() {
 		bgCtx := context.Background()
-		if err := h.Syncer.Sync(bgCtx, u); err != nil {
+		freshUser, err := h.Client.User.Get(bgCtx, userID)
+		if err != nil {
+			h.Logger.Error("failed to fetch user for reset sync", "error", err)
+			return
+		}
+		if err := h.Syncer.Sync(bgCtx, freshUser); err != nil {
 			h.Logger.Error("failed to sync after reset", "error", err)
 		}
 		// Also run metadata enrichment if available
 		if h.MetadataSvc != nil {
-			if err := h.MetadataSvc.SyncAll(bgCtx, u); err != nil {
+			if err := h.MetadataSvc.SyncAll(bgCtx, freshUser); err != nil {
 				h.Logger.Error("failed to run metadata after reset", "error", err)
 			}
 		}
@@ -989,21 +1078,28 @@ func (h *Handler) TaskCleanup(w http.ResponseWriter, r *http.Request) {
 		},
 	})
 
+	// Governing: SPEC graceful-shutdown REQ "background goroutines must not capture *ent.User pointer"
+	userID := u.ID
 	go func() {
 		bgCtx := context.Background()
+		freshUser, err := h.Client.User.Get(bgCtx, userID)
+		if err != nil {
+			h.Logger.Error("failed to fetch user for cleanup", "error", err)
+			return
+		}
 
 		// Delete events older than 30 days
 		cutoff := time.Now().AddDate(0, 0, -30)
 		deleted, err := h.Client.SyncEvent.Delete().
 			Where(
-				syncevent.HasUserWith(user.ID(u.ID)),
+				syncevent.HasUserWith(user.ID(userID)),
 				syncevent.CreatedAtLT(cutoff),
 			).
 			Exec(bgCtx)
 
 		if err != nil {
 			h.Logger.Error("failed to delete old events", "error", err)
-			h.Bus.Publish(u.ID, events.Event{
+			h.Bus.Publish(userID, events.Event{
 				Type: events.EventTypeNotification,
 				Payload: events.NotificationPayload{
 					Title:    "Cleanup Failed",
@@ -1014,13 +1110,13 @@ func (h *Handler) TaskCleanup(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		h.Logger.Info("cleanup completed", "username", u.Username, "events_deleted", deleted)
+		h.Logger.Info("cleanup completed", "username", freshUser.Username, "events_deleted", deleted)
 
-		h.logEvent(bgCtx, u, syncevent.EventTypeCleanupCompleted, "system",
+		h.logEvent(bgCtx, freshUser, syncevent.EventTypeCleanupCompleted, "system",
 			fmt.Sprintf("Cleanup completed: deleted %d events older than 30 days", deleted),
 			map[string]interface{}{"events_deleted": deleted})
 
-		h.Bus.Publish(u.ID, events.Event{
+		h.Bus.Publish(userID, events.Event{
 			Type: events.EventTypeNotification,
 			Payload: events.NotificationPayload{
 				Title:    "Cleanup Complete",

--- a/internal/handlers/vibes.go
+++ b/internal/handlers/vibes.go
@@ -656,24 +656,29 @@ func (h *Handler) GenerateMixtape(w http.ResponseWriter, r *http.Request) {
 		UserID:  u.ID,
 	}
 
+	// Governing: SPEC graceful-shutdown, SPEC vibes-ai-mixtape-engine REQ "background goroutines use context.Background()"
+	// Capture value types to avoid stale *ent.User pointer in goroutine
+	userID := u.ID
+	mixtapeName := m.Name
+	djName := m.Edges.Dj.Name
+
 	// Run generation (this can take a while, so we do it in a goroutine for async UX)
 	go func() {
-		// Governing: context.Background() prevents premature cancellation when HTTP handler returns
 		ctx := context.Background()
 
 		// Publish generating event
 		if h.Bus != nil {
-			h.Bus.PublishMixtapeGenerating(u.ID, m.ID, m.Name, m.Edges.Dj.Name)
+			h.Bus.PublishMixtapeGenerating(userID, mixtapeID, mixtapeName, djName)
 		}
 
 		result, err := h.MixtapeGenerator.GenerateMixtape(ctx, req)
 		if err != nil {
 			h.Logger.Error("mixtape generation failed",
-				"mixtape_id", m.ID,
+				"mixtape_id", mixtapeID,
 				"error", err)
 
 			// Update mixtape with error
-			if _, saveErr := h.Client.Mixtape.UpdateOneID(m.ID).
+			if _, saveErr := h.Client.Mixtape.UpdateOneID(mixtapeID).
 				SetGenerationError(err.Error()).
 				Save(ctx); saveErr != nil {
 				h.Logger.Error("failed to save mixtape error", "error", saveErr)
@@ -681,7 +686,7 @@ func (h *Handler) GenerateMixtape(w http.ResponseWriter, r *http.Request) {
 
 			// Publish error event
 			if h.Bus != nil {
-				h.Bus.PublishMixtapeError(u.ID, m.ID, m.Name, err.Error())
+				h.Bus.PublishMixtapeError(userID, mixtapeID, mixtapeName, err.Error())
 			}
 			return
 		}
@@ -690,7 +695,7 @@ func (h *Handler) GenerateMixtape(w http.ResponseWriter, r *http.Request) {
 		trackIDs := result.GetMatchedTrackIDsAsStrings()
 
 		// Update the mixtape with the results
-		updater := h.Client.Mixtape.UpdateOneID(m.ID).
+		updater := h.Client.Mixtape.UpdateOneID(mixtapeID).
 			SetTrackIds(trackIDs).
 			SetTrackCount(len(trackIDs)).
 			SetLastGeneratedAt(time.Now()).
@@ -721,20 +726,20 @@ func (h *Handler) GenerateMixtape(w http.ResponseWriter, r *http.Request) {
 		_, err = updater.Save(ctx)
 		if err != nil {
 			h.Logger.Error("failed to save mixtape generation results",
-				"mixtape_id", m.ID,
+				"mixtape_id", mixtapeID,
 				"error", err)
 			return
 		}
 
 		h.Logger.Info("mixtape generation complete",
-			"mixtape_id", m.ID,
+			"mixtape_id", mixtapeID,
 			"tracks_matched", result.MatchedCount,
 			"tracks_unmatched", result.UnmatchedCount,
 			"tokens_used", result.TokensUsed)
 
 		// Publish success event
 		if h.Bus != nil {
-			h.Bus.PublishMixtapeGenerated(u.ID, m.ID, m.Name, m.Edges.Dj.Name,
+			h.Bus.PublishMixtapeGenerated(userID, mixtapeID, mixtapeName, djName,
 				len(result.Tracks), result.MatchedCount, result.TokensUsed)
 		}
 	}()

--- a/internal/views/components/enhance_vibes_modal.templ
+++ b/internal/views/components/enhance_vibes_modal.templ
@@ -199,13 +199,14 @@ templ EnhanceVibesModalContent(params EnhanceVibesModalParams) {
 
 // EnhanceVibesButton renders the button that opens the enhance vibes modal.
 // This replaces the old "Enhance" button on playlist views.
+// Governing: SPEC vibes-ai-mixtape-engine REQ "modal opens only after HTMX content is loaded"
 templ EnhanceVibesButton(playlistID int, size string) {
 	<button
 		class={ "btn btn-accent gap-2", templ.KV("btn-sm", size == "sm") }
 		hx-get={ fmt.Sprintf("/playlists/%d/enhance-vibes-modal", playlistID) }
 		hx-target="#enhance-vibes-modal"
 		hx-swap="innerHTML"
-		onclick="document.getElementById('enhance-vibes-modal').showModal()"
+		_="on htmx:afterSettle from #enhance-vibes-modal call #enhance-vibes-modal.showModal()"
 	>
 		<span class="icon-[heroicons--sparkles] w-4 h-4"></span>
 		Enhance Vibes


### PR DESCRIPTION
## Summary

- **Buffer Templ component renders** in `handlers.go:Render()` to prevent double-write on template error (write to `bytes.Buffer` first, then to `ResponseWriter` only on success)
- **Fix stale `*ent.User` pointer in background goroutines** across `preferences.go`: capture `userID` (int) before the goroutine, then re-query a fresh `*ent.User` inside the goroutine using `context.Background()`
- **Fix `GenerateMixtape` goroutine** in `vibes.go`: capture value types (`userID`, `mixtapeName`, `djName`) instead of referencing pointer-based structs from the outer HTTP handler scope
- **Fix HTMX enhance modal race condition**: replace `onclick="...showModal()"` with `_="on htmx:afterSettle from #enhance-vibes-modal call #enhance-vibes-modal.showModal()"` so the modal opens only after HTMX finishes loading its content

Closes #95
Closes #96
Closes #103
Closes #115
Fixes #154

## Test plan

- [x] All existing tests pass (`make test`)
- [x] `go vet ./internal/handlers/` passes cleanly
- [ ] Manual: trigger a provider sync (Navidrome/Spotify/Last.fm) and verify sync completes successfully in the background
- [ ] Manual: trigger "Reset All Data" task and verify re-sync works
- [ ] Manual: open the "Enhance Vibes" modal on a playlist and verify modal content loads before the dialog opens
- [ ] Manual: cause a template render error and verify no double-write panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)