### PR TITLE
fix: use SameSite=Lax on session cookie for OAuth compatibility

### DIFF
--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -133,7 +133,9 @@ func (h *Handler) PostLogin(w http.ResponseWriter, r *http.Request) {
 		HttpOnly: true,
 		Secure:   h.Config.Security.SecureCookies,
 		Expires:  time.Now().Add(24 * time.Hour),
-		SameSite: http.SameSiteStrictMode,
+		// Governing: issue #161 — Lax (not Strict) allows session cookie to be sent in
+		// OAuth cross-site redirect chains (Spotify/LastFM → our callback → authenticated route)
+		SameSite: http.SameSiteLaxMode,
 	})
 
 	// Check if this is an HTMX request
@@ -155,7 +157,9 @@ func (h *Handler) Logout(w http.ResponseWriter, r *http.Request) {
 		HttpOnly: true,
 		Secure:   h.Config.Security.SecureCookies,
 		Expires:  time.Now().Add(-1 * time.Hour),
-		SameSite: http.SameSiteStrictMode,
+		// Governing: issue #161 — Lax (not Strict) allows session cookie to be sent in
+		// OAuth cross-site redirect chains (Spotify/LastFM → our callback → authenticated route)
+		SameSite: http.SameSiteLaxMode,
 		MaxAge:   -1,
 	})
 	http.Redirect(w, r, "/auth/login", http.StatusSeeOther)

--- a/internal/handlers/auth_test.go
+++ b/internal/handlers/auth_test.go
@@ -349,7 +349,7 @@ func TestPostLogin_SecureCookieFlag(t *testing.T) {
 			require.NotNil(t, sessionCookie, "Session cookie should be set")
 			assert.Equal(t, tc.expectedSecure, sessionCookie.Secure, "Cookie Secure flag should match config")
 			assert.True(t, sessionCookie.HttpOnly, "Cookie should be HttpOnly")
-			assert.Equal(t, http.SameSiteStrictMode, sessionCookie.SameSite, "Cookie should have SameSite=Strict")
+			assert.Equal(t, http.SameSiteLaxMode, sessionCookie.SameSite, "Session cookie should use SameSite=Lax for OAuth compatibility")
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Changes session cookie from `SameSite=Strict` to `SameSite=Lax` in `internal/handlers/auth.go` (both login and logout cookie setters)
- Updates auth test to assert `SameSite=Lax`

## Root Cause

`SameSite=Strict` cookies are blocked by browsers in cross-site redirect chains. When a user completes Spotify or LastFM OAuth authorization, the browser follows:

> Spotify/LastFM (external) → /auth/spotify/callback → /preferences/providers

The `SameSite=Strict` session cookie is not sent at any point in this chain because it originates from an external domain. AuthMiddleware then sees no session and redirects to /auth/login.

`SameSite=Lax` allows cookies in top-level cross-site GET navigations (which OAuth redirects are) while still blocking cross-site POST and sub-resource requests — providing adequate CSRF protection.

## Verified

- OAuth callback handlers (`spotify_auth.go`, `lastfm_auth.go`) correctly redirect to `/preferences/providers` on success
- Neither callback handler clears or overwrites the session cookie
- OAuth state cookies already use `SameSite=Lax` — only the session cookie was Strict
- No `Secure: true` with HTTP issues found

## Test Plan
- [ ] Log in to Spotter
- [ ] Navigate to Settings → Providers → Connect Spotify (or LastFM)
- [ ] Complete OAuth authorization
- [ ] Verify: land on /preferences/providers with session intact, no login redirect

Closes #161