### PR TITLE
fix: replace innerHTML toast with safe DOM API calls

### DIFF
--- a/internal/views/preferences/preferences.templ
+++ b/internal/views/preferences/preferences.templ
@@ -74,7 +74,7 @@ templ Appearance(user *ent.User, cfg *config.Config) {
 				localStorage.setItem('spotter-theme', theme);
 			}
 
-			// Show toast notification
+			// Show toast notification using safe DOM APIs (no innerHTML)
 			function showToast(message, type) {
 				const container = document.getElementById('toasts');
 				if (!container) return;
@@ -92,11 +92,15 @@ templ Appearance(user *ent.User, cfg *config.Config) {
 				}
 
 				toast.classList.add(alertClass);
-				toast.innerHTML = `
-					<span class="${iconClass} w-6 h-6"></span>
-					<span>${message}</span>
-				`;
 
+				const icon = document.createElement('span');
+				icon.className = iconClass + ' w-6 h-6';
+
+				const text = document.createElement('span');
+				text.textContent = message;
+
+				toast.appendChild(icon);
+				toast.appendChild(text);
 				container.appendChild(toast);
 
 				// Auto-remove after 4 seconds


### PR DESCRIPTION
## Summary

- Replaces `innerHTML` template literal in `showToast` with `createElement`/`textContent` DOM APIs
- No behavior change — same toast appearance, same auto-remove timing

## Motivation

Defense-in-depth: the `innerHTML` pattern is unsafe if `message` ever becomes server-controlled (e.g., error messages from API responses). DOM APIs using `textContent` are inherently XSS-safe.

## Test Plan
- [ ] Save preferences → success toast appears correctly
- [ ] Trigger a save error → error toast appears correctly
- [ ] Toast auto-dismisses after timeout

Closes #118