### PR TITLE
fix: nil guard for MetadataSvc in AI enricher handlers

### DIFF
--- a/internal/handlers/artists.go
+++ b/internal/handlers/artists.go
@@ -635,6 +635,10 @@ func (h *Handler) ArtistRegenerateAI(w http.ResponseWriter, r *http.Request) {
 
 // getAIEnricher returns the OpenAI enricher if available
 func (h *Handler) getAIEnricher(ctx context.Context, u *ent.User) ([]enrichers.Enricher, error) {
+	if h.MetadataSvc == nil {
+		return nil, nil
+	}
+
 	factory, ok := h.MetadataSvc.Registry.Get(enrichers.TypeOpenAI)
 	if !ok {
 		return nil, nil


### PR DESCRIPTION
## Summary

- Adds `if h.MetadataSvc == nil { return nil, nil }` at the top of `getAIEnricher` in `artists.go`
- Audited `albums.go` and `tracks.go` for any other unguarded `h.MetadataSvc` accesses — none found (they call `getAIEnricher` which is now guarded)
- All other `h.MetadataSvc.` dereferences in `preferences.go` already have proper nil guards

## Root Cause

`getAIEnricher` directly dereferences `h.MetadataSvc.Registry` without checking for nil. The existing `TaskEnrichMetadata` in `preferences.go` correctly guards against this; this fix applies the same pattern consistently.

## Test Plan
- [ ] Confirm server starts without MetadataSvc configured and hitting AI regeneration endpoints returns a graceful error (not a panic)

Closes #98