### PR TITLE
fix: pin Alpine.js CDN to exact version

### DIFF
--- a/internal/views/layouts/base.templ
+++ b/internal/views/layouts/base.templ
@@ -23,7 +23,7 @@ templ BaseWithTheme(title string, defaultTheme string) {
 			<script src="https://unpkg.com/htmx.org@1.9.10/dist/ext/sse.js"></script>
 			// Hyperscript: required for _="..." attributes in create_mixtape_modal, enhance_vibes_modal
 			<script src="https://unpkg.com/hyperscript.org@0.9.12"></script>
-			<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+			<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.8/dist/cdn.min.js"></script>
 			<script src="https://cdnjs.cloudflare.com/ajax/libs/timeago.js/4.0.2/timeago.min.js"></script>
 			<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
 			<link href="/static/css/output.css" rel="stylesheet"/>


### PR DESCRIPTION
## Summary

- Pins Alpine.js from `@3.x.x` to `@3.15.8` on jsDelivr CDN
- Consistent with other pinned CDN dependencies: htmx@1.9.10, timeago@4.0.2, chart.js@4.4.1

## Motivation

Floating version ranges create supply chain risk and reproducibility issues. A future Alpine.js patch/minor release could silently change behavior or introduce vulnerabilities that propagate to all users without any code change in the repo.

## Test Plan
- [ ] Application loads with Alpine.js-dependent components working (tag inputs, any x-data components)
- [ ] No console errors related to Alpine.js

Closes #128