### PR TITLE
fix: frontend polish — duplicate menu, capitalizeFirst, pagination a11y, collapse a11y

### DIFF
--- a/internal/views/albums/index.templ
+++ b/internal/views/albums/index.templ
@@ -172,7 +172,7 @@ templ Index(albums []*ent.Album, currentPage int, totalPages int, cfg *config.Co
 							if currentPage > 1 {
 								<a href={ templ.URL(buildAlbumPaginationURL(currentPage-1, artistFilter)) } class="join-item btn btn-sm">«</a>
 							} else {
-								<button class="join-item btn btn-sm btn-disabled">«</button>
+								<button class="join-item btn btn-sm btn-disabled" disabled>«</button>
 							}
 							for i := 1; i <= totalPages; i++ {
 								if i == currentPage {
@@ -180,13 +180,13 @@ templ Index(albums []*ent.Album, currentPage int, totalPages int, cfg *config.Co
 								} else if i == 1 || i == totalPages || (i >= currentPage-2 && i <= currentPage+2) {
 									<a href={ templ.URL(buildAlbumPaginationURL(i, artistFilter)) } class="join-item btn btn-sm">{ fmt.Sprintf("%d", i) }</a>
 								} else if i == currentPage-3 || i == currentPage+3 {
-									<button class="join-item btn btn-sm btn-disabled">...</button>
+									<button class="join-item btn btn-sm btn-disabled" disabled>...</button>
 								}
 							}
 							if currentPage < totalPages {
 								<a href={ templ.URL(buildAlbumPaginationURL(currentPage+1, artistFilter)) } class="join-item btn btn-sm">»</a>
 							} else {
-								<button class="join-item btn btn-sm btn-disabled">»</button>
+								<button class="join-item btn btn-sm btn-disabled" disabled>»</button>
 							}
 						</div>
 					</div>

--- a/internal/views/albums/show.templ
+++ b/internal/views/albums/show.templ
@@ -282,26 +282,6 @@ templ Show(album *ent.Album, tracks []TrackWithListens, stats *AlbumStats, djs [
 								</a>
 							}
 						</li>
-						<li>
-							if len(djs) > 0 {
-								<button
-									hx-get={ fmt.Sprintf("/library/album/%d/mixtape-modal", album.ID) }
-									hx-target="#create-mixtape-modal"
-									hx-swap="innerHTML"
-									onclick="this.closest('details').removeAttribute('open')"
-									_="on htmx:afterRequest document.getElementById('create-mixtape-modal').showModal()"
-								>
-									<span class="icon-[heroicons--musical-note] w-4 h-4"></span>
-									Create Mixtape
-								</button>
-							} else {
-								<a href="/vibes/djs" class="opacity-60">
-									<span class="icon-[heroicons--musical-note] w-4 h-4"></span>
-									Create Mixtape
-									<span class="badge badge-xs">Create DJ first</span>
-								</a>
-							}
-						</li>
 					</ul>
 				</details>
 			</div>

--- a/internal/views/artists/index.templ
+++ b/internal/views/artists/index.templ
@@ -144,7 +144,7 @@ templ Index(artists []*ent.Artist, currentPage int, totalPages int, cfg *config.
 							if currentPage > 1 {
 								<a href={ templ.URL(fmt.Sprintf("/library/artists?page=%d", currentPage-1)) } class="join-item btn btn-sm">«</a>
 							} else {
-								<button class="join-item btn btn-sm btn-disabled">«</button>
+								<button class="join-item btn btn-sm btn-disabled" disabled>«</button>
 							}
 							for i := 1; i <= totalPages; i++ {
 								if i == currentPage {
@@ -152,13 +152,13 @@ templ Index(artists []*ent.Artist, currentPage int, totalPages int, cfg *config.
 								} else if i == 1 || i == totalPages || (i >= currentPage-2 && i <= currentPage+2) {
 									<a href={ templ.URL(fmt.Sprintf("/library/artists?page=%d", i)) } class="join-item btn btn-sm">{ fmt.Sprintf("%d", i) }</a>
 								} else if i == currentPage-3 || i == currentPage+3 {
-									<button class="join-item btn btn-sm btn-disabled">...</button>
+									<button class="join-item btn btn-sm btn-disabled" disabled>...</button>
 								}
 							}
 							if currentPage < totalPages {
 								<a href={ templ.URL(fmt.Sprintf("/library/artists?page=%d", currentPage+1)) } class="join-item btn btn-sm">»</a>
 							} else {
-								<button class="join-item btn btn-sm btn-disabled">»</button>
+								<button class="join-item btn btn-sm btn-disabled" disabled>»</button>
 							}
 						</div>
 					</div>

--- a/internal/views/components/enhance_vibes_modal.templ
+++ b/internal/views/components/enhance_vibes_modal.templ
@@ -134,7 +134,7 @@ templ EnhanceVibesModalContent(params EnhanceVibesModalParams) {
 			</div>
 			<!-- Mode Details Accordion -->
 			<div class="collapse collapse-arrow bg-base-200 mb-4">
-				<input type="checkbox"/>
+				<input type="checkbox" aria-label="Toggle What's the difference section"/>
 				<div class="collapse-title text-sm font-medium">
 					<span class="icon-[heroicons--question-mark-circle] w-4 h-4 inline-block mr-1"></span>
 					What's the difference?

--- a/internal/views/components/track_match_results.templ
+++ b/internal/views/components/track_match_results.templ
@@ -77,7 +77,7 @@ templ TrackMatchDetails(config TrackMatchDisplayConfig) {
 			if len(config.UnmatchedTracks) > 0 {
 				<div class="divider my-3"></div>
 				<div class="collapse collapse-arrow bg-base-200 rounded-lg">
-					<input type="checkbox"/>
+					<input type="checkbox" aria-label="Toggle Unmatched Tracks section"/>
 					<div class="collapse-title font-medium flex items-center gap-2">
 						<span class="icon-[heroicons--exclamation-triangle] w-5 h-5 text-warning"></span>
 						{ fmt.Sprintf("Unmatched Tracks (%d)", len(config.UnmatchedTracks)) }

--- a/internal/views/playlists/index.templ
+++ b/internal/views/playlists/index.templ
@@ -244,7 +244,7 @@ templ Index(playlists []*ent.Playlist, currentPage int, totalPages int, cfg *con
 							if currentPage > 1 {
 								<a href={ templ.URL(fmt.Sprintf("/playlists?page=%d", currentPage-1)) } class="join-item btn btn-sm">«</a>
 							} else {
-								<button class="join-item btn btn-sm btn-disabled">«</button>
+								<button class="join-item btn btn-sm btn-disabled" disabled>«</button>
 							}
 							for i := 1; i <= totalPages; i++ {
 								if i == currentPage {
@@ -252,13 +252,13 @@ templ Index(playlists []*ent.Playlist, currentPage int, totalPages int, cfg *con
 								} else if i == 1 || i == totalPages || (i >= currentPage-2 && i <= currentPage+2) {
 									<a href={ templ.URL(fmt.Sprintf("/playlists?page=%d", i)) } class="join-item btn btn-sm">{ fmt.Sprintf("%d", i) }</a>
 								} else if i == currentPage-3 || i == currentPage+3 {
-									<button class="join-item btn btn-sm btn-disabled">...</button>
+									<button class="join-item btn btn-sm btn-disabled" disabled>...</button>
 								}
 							}
 							if currentPage < totalPages {
 								<a href={ templ.URL(fmt.Sprintf("/playlists?page=%d", currentPage+1)) } class="join-item btn btn-sm">»</a>
 							} else {
-								<button class="join-item btn btn-sm btn-disabled">»</button>
+								<button class="join-item btn btn-sm btn-disabled" disabled>»</button>
 							}
 						</div>
 					</div>

--- a/internal/views/playlists/show.templ
+++ b/internal/views/playlists/show.templ
@@ -7,6 +7,8 @@ import (
 	"spotter/internal/views/components"
 	"spotter/internal/views/layouts"
 	"time"
+	"unicode"
+	"unicode/utf8"
 )
 
 func showFormatDate(t time.Time) string {
@@ -165,7 +167,8 @@ func capitalizeFirst(s string) string {
 	if s == "" {
 		return s
 	}
-	return string(s[0]-32) + s[1:]
+	r, size := utf8.DecodeRuneInString(s)
+	return string(unicode.ToUpper(r)) + s[size:]
 }
 
 func formatSyncStatus(playlist *ent.Playlist) string {

--- a/internal/views/recent/list.templ
+++ b/internal/views/recent/list.templ
@@ -92,7 +92,7 @@ templ Index(rows []components.TrackTableRow, currentPage int, totalPages int, cf
 							if currentPage > 1 {
 								<a href={ templ.URL(buildPaginationURL(currentPage-1, artistFilter, sortCol, sortDir)) } class="join-item btn btn-sm">«</a>
 							} else {
-								<button class="join-item btn btn-sm btn-disabled">«</button>
+								<button class="join-item btn btn-sm btn-disabled" disabled>«</button>
 							}
 							for i := 1; i <= totalPages; i++ {
 								if i == currentPage {
@@ -100,13 +100,13 @@ templ Index(rows []components.TrackTableRow, currentPage int, totalPages int, cf
 								} else if i == 1 || i == totalPages || (i >= currentPage-2 && i <= currentPage+2) {
 									<a href={ templ.URL(buildPaginationURL(i, artistFilter, sortCol, sortDir)) } class="join-item btn btn-sm">{ fmt.Sprintf("%d", i) }</a>
 								} else if i == currentPage-3 || i == currentPage+3 {
-									<button class="join-item btn btn-sm btn-disabled">...</button>
+									<button class="join-item btn btn-sm btn-disabled" disabled>...</button>
 								}
 							}
 							if currentPage < totalPages {
 								<a href={ templ.URL(buildPaginationURL(currentPage+1, artistFilter, sortCol, sortDir)) } class="join-item btn btn-sm">»</a>
 							} else {
-								<button class="join-item btn btn-sm btn-disabled">»</button>
+								<button class="join-item btn btn-sm btn-disabled" disabled>»</button>
 							}
 						</div>
 					</div>

--- a/internal/views/tracks/index.templ
+++ b/internal/views/tracks/index.templ
@@ -102,7 +102,7 @@ templ Index(tracks []*ent.Track, currentPage int, totalPages int, cfg *config.Co
 							if currentPage > 1 {
 								<a href={ templ.URL(buildTrackPaginationURL(currentPage-1, artistFilter, sortCol, sortDir)) } class="join-item btn btn-sm">«</a>
 							} else {
-								<button class="join-item btn btn-sm btn-disabled">«</button>
+								<button class="join-item btn btn-sm btn-disabled" disabled>«</button>
 							}
 							for i := 1; i <= totalPages; i++ {
 								if i == currentPage {
@@ -110,13 +110,13 @@ templ Index(tracks []*ent.Track, currentPage int, totalPages int, cfg *config.Co
 								} else if i == 1 || i == totalPages || (i >= currentPage-2 && i <= currentPage+2) {
 									<a href={ templ.URL(buildTrackPaginationURL(i, artistFilter, sortCol, sortDir)) } class="join-item btn btn-sm">{ fmt.Sprintf("%d", i) }</a>
 								} else if i == currentPage-3 || i == currentPage+3 {
-									<button class="join-item btn btn-sm btn-disabled">...</button>
+									<button class="join-item btn btn-sm btn-disabled" disabled>...</button>
 								}
 							}
 							if currentPage < totalPages {
 								<a href={ templ.URL(buildTrackPaginationURL(currentPage+1, artistFilter, sortCol, sortDir)) } class="join-item btn btn-sm">»</a>
 							} else {
-								<button class="join-item btn btn-sm btn-disabled">»</button>
+								<button class="join-item btn btn-sm btn-disabled" disabled>»</button>
 							}
 						</div>
 					</div>

--- a/internal/views/vibes/mixtape_show.templ
+++ b/internal/views/vibes/mixtape_show.templ
@@ -316,7 +316,7 @@ templ MixtapeShow(m *ent.Mixtape, tracks []*ent.Track, djs []*ent.DJ, cfg *confi
 			// GenerationPrompt rendered via Templ string interpolation {}, which auto-escapes HTML
 			if m.GenerationPrompt != "" {
 				<div class="collapse collapse-arrow bg-base-100 shadow-xl mb-8">
-					<input type="checkbox"/>
+					<input type="checkbox" aria-label="Toggle Generation Prompt section"/>
 					<div class="collapse-title text-lg font-medium flex items-center gap-2">
 						<span class="icon-[heroicons--document-text] w-5 h-5"></span>
 						Generation Prompt

--- a/internal/views/vibes/mixtapes.templ
+++ b/internal/views/vibes/mixtapes.templ
@@ -317,7 +317,7 @@ templ MixtapesIndex(mixtapes []*ent.Mixtape, djs []*ent.DJ, currentPage int, tot
 							if currentPage > 1 {
 								<a href={ templ.URL(fmt.Sprintf("/vibes/mixtapes?page=%d", currentPage-1)) } class="join-item btn btn-sm">«</a>
 							} else {
-								<button class="join-item btn btn-sm btn-disabled">«</button>
+								<button class="join-item btn btn-sm btn-disabled" disabled>«</button>
 							}
 							for i := 1; i <= totalPages; i++ {
 								if i == currentPage {
@@ -325,13 +325,13 @@ templ MixtapesIndex(mixtapes []*ent.Mixtape, djs []*ent.DJ, currentPage int, tot
 								} else if i == 1 || i == totalPages || (i >= currentPage-2 && i <= currentPage+2) {
 									<a href={ templ.URL(fmt.Sprintf("/vibes/mixtapes?page=%d", i)) } class="join-item btn btn-sm">{ fmt.Sprintf("%d", i) }</a>
 								} else if i == currentPage-3 || i == currentPage+3 {
-									<button class="join-item btn btn-sm btn-disabled">...</button>
+									<button class="join-item btn btn-sm btn-disabled" disabled>...</button>
 								}
 							}
 							if currentPage < totalPages {
 								<a href={ templ.URL(fmt.Sprintf("/vibes/mixtapes?page=%d", currentPage+1)) } class="join-item btn btn-sm">»</a>
 							} else {
-								<button class="join-item btn btn-sm btn-disabled">»</button>
+								<button class="join-item btn btn-sm btn-disabled" disabled>»</button>
 							}
 						</div>
 					</div>


### PR DESCRIPTION
## Summary

Fixes 4 small frontend issues in one PR:

- **#111**: Remove duplicate 'Create Mixtape' menu item in `albums/show.templ` (copy-paste error)
- **#112**: Replace unsafe `s[0]-32` byte arithmetic in `capitalizeFirst` with Unicode-safe `utf8.DecodeRuneInString` + `unicode.ToUpper`
- **#117**: Add HTML `disabled` attribute to all `btn-disabled` pagination buttons (accessibility — WCAG 4.1.2)
- **#126**: Add `aria-label` to unlabeled DaisyUI collapse checkbox inputs (accessibility — WCAG 4.1.2)

## Test Plan
- [ ] Album detail AI menu shows only one 'Create Mixtape' item
- [ ] Playlist page shows correct capitalization for source names
- [ ] Pagination disabled buttons are not keyboard-focusable
- [ ] Screen reader announces collapse sections correctly

Closes #111
Closes #112
Closes #117
Closes #126