### PR TITLE
refactor: replace duplicated nopHandler with stdlib slog.DiscardHandler

### DIFF
--- a/internal/enrichers/openai/openai.go
+++ b/internal/enrichers/openai/openai.go
@@ -27,14 +27,6 @@ import (
 	_ "golang.org/x/image/webp"
 )
 
-// nopHandler is a slog handler that discards all log records.
-type nopHandler struct{}
-
-func (nopHandler) Enabled(context.Context, slog.Level) bool  { return false }
-func (nopHandler) Handle(context.Context, slog.Record) error { return nil }
-func (h nopHandler) WithAttrs([]slog.Attr) slog.Handler      { return h }
-func (h nopHandler) WithGroup(string) slog.Handler           { return h }
-
 const (
 	defaultTimeout = 120 * time.Second
 	defaultModel   = "gpt-4o"
@@ -228,7 +220,7 @@ func New(logger *slog.Logger, cfg *config.Config) enrichers.Factory {
 
 		// Use a no-op logger if none provided
 		if logger == nil {
-			logger = slog.New(nopHandler{})
+			logger = slog.New(slog.DiscardHandler)
 		}
 
 		e := &Enricher{

--- a/internal/vibes/enhancer.go
+++ b/internal/vibes/enhancer.go
@@ -40,7 +40,7 @@ type PlaylistEnhancer struct {
 // NewPlaylistEnhancer creates a new PlaylistEnhancer service.
 func NewPlaylistEnhancer(client *ent.Client, cfg *config.Config, logger *slog.Logger, bus *events.Bus) *PlaylistEnhancer {
 	if logger == nil {
-		logger = slog.New(nopHandler{})
+		logger = slog.New(slog.DiscardHandler)
 	}
 
 	timeout := time.Duration(cfg.Vibes.TimeoutSeconds) * time.Second

--- a/internal/vibes/generator.go
+++ b/internal/vibes/generator.go
@@ -25,14 +25,6 @@ import (
 	"spotter/internal/events"
 )
 
-// nopHandler is a slog handler that discards all log records.
-type nopHandler struct{}
-
-func (nopHandler) Enabled(context.Context, slog.Level) bool  { return false }
-func (nopHandler) Handle(context.Context, slog.Record) error { return nil }
-func (h nopHandler) WithAttrs([]slog.Attr) slog.Handler      { return h }
-func (h nopHandler) WithGroup(string) slog.Handler           { return h }
-
 // MixtapeGenerator implements the Generator interface for creating AI-powered mixtapes.
 type MixtapeGenerator struct {
 	client     *ent.Client
@@ -48,7 +40,7 @@ type MixtapeGenerator struct {
 func NewMixtapeGenerator(client *ent.Client, cfg *config.Config, logger *slog.Logger, bus *events.Bus) *MixtapeGenerator {
 	// Use a no-op logger if none provided
 	if logger == nil {
-		logger = slog.New(nopHandler{})
+		logger = slog.New(slog.DiscardHandler)
 	}
 
 	// Governing: SPEC vibes-ai-mixtape-engine REQ-VIBES-030 — configurable HTTP timeout, default 120s


### PR DESCRIPTION
## Summary

- Removes private `nopHandler` from `internal/enrichers/openai/openai.go`
- Removes private `nopHandler` from `internal/vibes/generator.go` (also used by `enhancer.go`)
- Replaces all usages with `slog.DiscardHandler` from Go 1.24 stdlib
- Net result: -19 lines of duplicated code, zero new files

Since Go 1.24 ships `slog.DiscardHandler` as a built-in discard handler, there is no need for a custom `nopHandler` or a shared `internal/logging` package.

## Test Plan
- [ ] `go build ./...` passes
- [ ] Enricher and vibes packages compile correctly

Closes #121