### PR TITLE
fix: show inline error message on failed login

### DIFF
--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -22,7 +22,8 @@ func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/", http.StatusSeeOther)
 		return
 	}
-	h.Render(w, r, auth.Login(h.Config.Navidrome.BaseURL))
+	errorMsg := r.URL.Query().Get("error")
+	h.Render(w, r, auth.Login(h.Config.Navidrome.BaseURL, errorMsg))
 }
 
 func (h *Handler) PostLogin(w http.ResponseWriter, r *http.Request) {
@@ -44,9 +45,8 @@ func (h *Handler) PostLogin(w http.ResponseWriter, r *http.Request) {
 	// 1. Authenticate against Navidrome
 	if err := h.authenticateNavidrome(username, password); err != nil {
 		h.Logger.Error("Navidrome authentication failed", "error", err)
-		// Return error to HTMX
-		w.Header().Set("HX-Retarget", "body") // Optionally retarget to show error
-		http.Error(w, "Invalid credentials or Navidrome error", http.StatusUnauthorized)
+		w.WriteHeader(http.StatusUnauthorized)
+		h.Render(w, r, auth.Login(h.Config.Navidrome.BaseURL, "Invalid username or password. Please try again."))
 		return
 	}
 

--- a/internal/views/auth/login.templ
+++ b/internal/views/auth/login.templ
@@ -2,7 +2,7 @@ package auth
 
 import "spotter/internal/views/layouts"
 
-templ Login(navidromeURL string) {
+templ Login(navidromeURL string, errorMsg string) {
 	@layouts.Base("Login | Spotter") {
 		<div class="hero min-h-screen bg-base-200">
 			<div class="hero-content flex-col">
@@ -16,6 +16,12 @@ templ Login(navidromeURL string) {
 							</div>
 							<h1 class="text-4xl font-bold text-primary tracking-wide">Spotter</h1>
 						</div>
+						if errorMsg != "" {
+							<div class="alert alert-error shadow-sm">
+								<span class="icon-[heroicons--exclamation-triangle] w-5 h-5"></span>
+								<span>{ errorMsg }</span>
+							</div>
+						}
 						<form class="space-y-4" action="/login" method="POST" hx-post="/login" hx-target="body">
 							<div class="form-control">
 								<label class="label" for="username">


### PR DESCRIPTION
## Summary

- Adds `errorMsg` parameter to the login templ component
- Login POST handler re-renders the form with an error message on failure instead of returning a plain text HTTP error
- GET /login handler passes `?error=` query params to the template for OAuth callback errors

## Test Plan
- [ ] Submit login form with wrong password -> error message appears inline
- [ ] Submit login form with correct credentials -> redirects to app normally
- [ ] OAuth error redirect (e.g., `/auth/login?error=session_expired`) shows error message

Closes #120