### PR TITLE
fix: skip empty local_path in artist/album image selection

### DIFF
--- a/internal/handlers/images.go
+++ b/internal/handlers/images.go
@@ -56,24 +56,30 @@ func (h *Handler) ArtistImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Prefer primary thumbnail, then any primary, then first image
+	// Governing: issue #127 — skip records with empty local_path to avoid serving 404 when primary image wasn't downloaded
+	// Prefer primary thumbnail, then any primary, then first image with a valid path
 	var localPath string
 	for _, img := range a.Edges.Images {
-		if img.IsPrimary && string(img.ImageType) == "thumbnail" {
+		if img.IsPrimary && string(img.ImageType) == "thumbnail" && img.LocalPath != "" {
 			localPath = img.LocalPath
 			break
 		}
 	}
 	if localPath == "" {
 		for _, img := range a.Edges.Images {
-			if img.IsPrimary {
+			if img.IsPrimary && img.LocalPath != "" {
 				localPath = img.LocalPath
 				break
 			}
 		}
 	}
 	if localPath == "" {
-		localPath = a.Edges.Images[0].LocalPath
+		for _, img := range a.Edges.Images {
+			if img.LocalPath != "" {
+				localPath = img.LocalPath
+				break
+			}
+		}
 	}
 
 	h.serveImage(w, r, localPath)
@@ -119,16 +125,22 @@ func (h *Handler) AlbumImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Prefer primary image, then first image
+	// Governing: issue #127 — skip records with empty local_path to avoid serving 404 when primary image wasn't downloaded
+	// Prefer primary image, then first image with a valid path
 	var localPath string
 	for _, img := range a.Edges.Images {
-		if img.IsPrimary {
+		if img.IsPrimary && img.LocalPath != "" {
 			localPath = img.LocalPath
 			break
 		}
 	}
 	if localPath == "" {
-		localPath = a.Edges.Images[0].LocalPath
+		for _, img := range a.Edges.Images {
+			if img.LocalPath != "" {
+				localPath = img.LocalPath
+				break
+			}
+		}
 	}
 
 	h.serveImage(w, r, localPath)


### PR DESCRIPTION
## Summary

- Adds `img.LocalPath != ""` guard to each image selection loop in `ArtistImage` and `AlbumImage` handlers
- Previously, if the primary image had no downloaded file, the handler served 404 "No image available" instead of falling back to the next valid image
- Fixes a production issue affecting 50 artists where Spotify thumbnail records were marked primary before the file was downloaded

## Root Cause

Image records can be persisted with `is_primary=true` before the local file download completes, leaving `local_path = ''`. The selection code found the primary record and stopped looking, resulting in an empty path sent to `serveImage()`.

## Test Plan
- [ ] Artist pages load images for artists that previously showed "No image available"
- [ ] Artists with valid primary images still work correctly
- [ ] Album images still load correctly

Part of #127