### PR TITLE
refactor: extract shared internal/llm package for OpenAI Chat Completions

### DIFF
--- a/internal/enrichers/openai/openai.go
+++ b/internal/enrichers/openai/openai.go
@@ -10,9 +10,7 @@ import (
 	_ "image/gif"
 	"image/jpeg"
 	_ "image/png"
-	"io"
 	"log/slog"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,6 +20,7 @@ import (
 	"spotter/ent"
 	"spotter/internal/config"
 	"spotter/internal/enrichers"
+	"spotter/internal/llm"
 
 	"github.com/nfnt/resize"
 	_ "golang.org/x/image/webp"
@@ -42,10 +41,10 @@ const (
 
 // Enricher implements the OpenAI metadata enricher.
 type Enricher struct {
-	logger     *slog.Logger
-	config     *config.Config
-	httpClient *http.Client
-	templates  map[string]*template.Template
+	logger    *slog.Logger
+	config    *config.Config
+	llm       *llm.Client
+	templates map[string]*template.Template
 }
 
 // Ensure Enricher implements interfaces
@@ -164,61 +163,6 @@ type TrackTemplateData struct {
 	AlbumGenre       string
 }
 
-// OpenAI API types
-type ChatMessage struct {
-	Role    string        `json:"role"`
-	Content []ContentPart `json:"content"`
-}
-
-type ContentPart struct {
-	Type     string    `json:"type"`
-	Text     string    `json:"text,omitempty"`
-	ImageURL *ImageURL `json:"image_url,omitempty"`
-}
-
-type ImageURL struct {
-	URL    string `json:"url"`
-	Detail string `json:"detail,omitempty"`
-}
-
-// ResponseFormat specifies the format of the response from OpenAI.
-type ResponseFormat struct {
-	Type string `json:"type"`
-}
-
-type ChatRequest struct {
-	Model          string          `json:"model"`
-	Messages       []ChatMessage   `json:"messages"`
-	MaxTokens      int             `json:"max_tokens,omitempty"`
-	Temperature    float64         `json:"temperature,omitempty"`
-	ResponseFormat *ResponseFormat `json:"response_format,omitempty"`
-}
-
-type ChatResponse struct {
-	ID      string `json:"id"`
-	Object  string `json:"object"`
-	Created int64  `json:"created"`
-	Model   string `json:"model"`
-	Choices []struct {
-		Index   int `json:"index"`
-		Message struct {
-			Role    string `json:"role"`
-			Content string `json:"content"`
-		} `json:"message"`
-		FinishReason string `json:"finish_reason"`
-	} `json:"choices"`
-	Usage struct {
-		PromptTokens     int `json:"prompt_tokens"`
-		CompletionTokens int `json:"completion_tokens"`
-		TotalTokens      int `json:"total_tokens"`
-	} `json:"usage"`
-	Error *struct {
-		Message string `json:"message"`
-		Type    string `json:"type"`
-		Code    string `json:"code"`
-	} `json:"error,omitempty"`
-}
-
 // New creates a new OpenAI enricher factory.
 func New(logger *slog.Logger, cfg *config.Config) enrichers.Factory {
 	return func(ctx context.Context, user *ent.User) (enrichers.Enricher, error) {
@@ -234,9 +178,11 @@ func New(logger *slog.Logger, cfg *config.Config) enrichers.Factory {
 		e := &Enricher{
 			logger: logger,
 			config: cfg,
-			httpClient: &http.Client{
+			llm: llm.NewClient(llm.ClientConfig{
+				APIKey:  cfg.OpenAI.APIKey,
+				BaseURL: cfg.OpenAI.BaseURL,
 				Timeout: defaultTimeout,
-			},
+			}),
 			templates: make(map[string]*template.Template),
 		}
 
@@ -299,22 +245,15 @@ func (e *Enricher) loadTemplates() error {
 
 // callOpenAI makes a request to the OpenAI API.
 func (e *Enricher) callOpenAI(ctx context.Context, prompt string, images []string) (string, error) {
-	baseURL := e.config.OpenAI.BaseURL
-	if baseURL == "" {
-		baseURL = "https://api.openai.com/v1"
-	}
-	// Ensure no trailing slash
-	baseURL = strings.TrimSuffix(baseURL, "/")
-
 	model := e.config.OpenAI.Model
 	if model == "" {
 		model = defaultModel
 	}
 
-	e.logger.Debug("preparing OpenAI request", "base_url", baseURL, "model", model, "prompt_length", len(prompt), "image_count", len(images))
+	e.logger.Debug("preparing OpenAI request", "model", model, "prompt_length", len(prompt), "image_count", len(images))
 
 	// Build content parts
-	content := []ContentPart{
+	content := []llm.ContentPart{
 		{
 			Type: "text",
 			Text: prompt,
@@ -329,18 +268,18 @@ func (e *Enricher) callOpenAI(ctx context.Context, prompt string, images []strin
 			continue
 		}
 
-		content = append(content, ContentPart{
+		content = append(content, llm.ContentPart{
 			Type: "image_url",
-			ImageURL: &ImageURL{
+			ImageURL: &llm.ImageURL{
 				URL:    fmt.Sprintf("data:image/jpeg;base64,%s", imgData),
 				Detail: "low", // Use low detail to save tokens
 			},
 		})
 	}
 
-	req := ChatRequest{
+	req := llm.ChatRequest{
 		Model: model,
-		Messages: []ChatMessage{
+		Messages: []llm.ChatMessage{
 			{
 				Role:    "user",
 				Content: content,
@@ -348,63 +287,18 @@ func (e *Enricher) callOpenAI(ctx context.Context, prompt string, images []strin
 		},
 		MaxTokens:   2000,
 		Temperature: 0.7,
-		ResponseFormat: &ResponseFormat{
+		ResponseFormat: &llm.ResponseFormat{
 			Type: "json_object",
 		},
 	}
 
-	reqBody, err := json.Marshal(req)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal request: %w", err)
-	}
-
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", baseURL+"/chat/completions", bytes.NewReader(reqBody))
-	if err != nil {
-		return "", fmt.Errorf("failed to create request: %w", err)
-	}
-
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+e.config.OpenAI.APIKey)
-
-	e.logger.Debug("sending OpenAI request", "url", baseURL+"/chat/completions")
-
-	resp, err := e.httpClient.Do(httpReq)
+	resp, err := e.llm.Chat(ctx, req)
 	if err != nil {
 		e.logger.Error("OpenAI request failed", "error", err)
 		return "", fmt.Errorf("request failed: %w", err)
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			e.logger.Warn("failed to close response body", "error", err)
-		}
-	}()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("failed to read response: %w", err)
-	}
-
-	e.logger.Debug("received OpenAI response", "status", resp.StatusCode, "body_length", len(body))
-
-	if resp.StatusCode != http.StatusOK {
-		e.logger.Error("OpenAI API error", "status", resp.StatusCode, "body", string(body))
-		return "", fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
-	}
-
-	var chatResp ChatResponse
-	if err := json.Unmarshal(body, &chatResp); err != nil {
-		return "", fmt.Errorf("failed to parse response: %w", err)
-	}
-
-	if chatResp.Error != nil {
-		return "", fmt.Errorf("API error: %s", chatResp.Error.Message)
-	}
-
-	if len(chatResp.Choices) == 0 {
-		return "", fmt.Errorf("no choices in response")
-	}
-
-	return chatResp.Choices[0].Message.Content, nil
+	return resp.Choices[0].Message.Content, nil
 }
 
 // loadImageAsBase64 loads an image file and returns it as base64.

--- a/internal/enrichers/openai/openai_test.go
+++ b/internal/enrichers/openai/openai_test.go
@@ -13,6 +13,7 @@ import (
 	"spotter/ent"
 	"spotter/internal/config"
 	"spotter/internal/enrichers"
+	"spotter/internal/llm"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -215,15 +216,8 @@ func TestEnrichArtist_MockAPI(t *testing.T) {
 		assert.Equal(t, "/chat/completions", r.URL.Path)
 		assert.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
 
-		response := ChatResponse{
-			Choices: []struct {
-				Index   int `json:"index"`
-				Message struct {
-					Role    string `json:"role"`
-					Content string `json:"content"`
-				} `json:"message"`
-				FinishReason string `json:"finish_reason"`
-			}{
+		response := llm.ChatResponse{
+			Choices: []llm.ChatChoice{
 				{
 					Index: 0,
 					Message: struct {
@@ -295,15 +289,8 @@ func TestEnrichArtist_SkipRecentlyEnriched(t *testing.T) {
 func TestEnrichAlbum_MockAPI(t *testing.T) {
 	// Create mock server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		response := ChatResponse{
-			Choices: []struct {
-				Index   int `json:"index"`
-				Message struct {
-					Role    string `json:"role"`
-					Content string `json:"content"`
-				} `json:"message"`
-				FinishReason string `json:"finish_reason"`
-			}{
+		response := llm.ChatResponse{
+			Choices: []llm.ChatChoice{
 				{
 					Index: 0,
 					Message: struct {
@@ -353,15 +340,8 @@ func TestEnrichAlbum_MockAPI(t *testing.T) {
 func TestEnrichTrack_MockAPI(t *testing.T) {
 	// Create mock server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		response := ChatResponse{
-			Choices: []struct {
-				Index   int `json:"index"`
-				Message struct {
-					Role    string `json:"role"`
-					Content string `json:"content"`
-				} `json:"message"`
-				FinishReason string `json:"finish_reason"`
-			}{
+		response := llm.ChatResponse{
+			Choices: []llm.ChatChoice{
 				{
 					Index: 0,
 					Message: struct {

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -1,0 +1,164 @@
+// Package llm provides a shared client for OpenAI Chat Completions API.
+// Governing: ADR-0008 (OpenAI API choice), issue #119
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// ChatMessage represents a single message in a chat completion request.
+type ChatMessage struct {
+	Role    string      `json:"role"`
+	Content interface{} `json:"content"` // string or []ContentPart for multi-modal
+}
+
+// ContentPart is used for multi-modal (text + image) messages.
+type ContentPart struct {
+	Type     string    `json:"type"`
+	Text     string    `json:"text,omitempty"`
+	ImageURL *ImageURL `json:"image_url,omitempty"`
+}
+
+// ImageURL holds an image URL for vision requests.
+type ImageURL struct {
+	URL    string `json:"url"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// ResponseFormat specifies the format of the response from OpenAI.
+type ResponseFormat struct {
+	Type string `json:"type"`
+}
+
+// ChatRequest is the payload for POST /v1/chat/completions.
+type ChatRequest struct {
+	Model          string          `json:"model"`
+	Messages       []ChatMessage   `json:"messages"`
+	MaxTokens      int             `json:"max_tokens,omitempty"`
+	Temperature    float64         `json:"temperature,omitempty"`
+	ResponseFormat *ResponseFormat `json:"response_format,omitempty"`
+}
+
+// ChatChoice is one completion choice in the response.
+type ChatChoice struct {
+	Index   int `json:"index"`
+	Message struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	} `json:"message"`
+	FinishReason string `json:"finish_reason"`
+}
+
+// ChatUsage contains token usage information from the API response.
+type ChatUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+// ChatError is the error object returned by the OpenAI API on failure.
+type ChatError struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+	Code    string `json:"code"`
+}
+
+// ChatResponse is the response from POST /v1/chat/completions.
+type ChatResponse struct {
+	ID      string       `json:"id"`
+	Object  string       `json:"object"`
+	Created int64        `json:"created"`
+	Model   string       `json:"model"`
+	Choices []ChatChoice `json:"choices"`
+	Usage   *ChatUsage   `json:"usage"`
+	Error   *ChatError   `json:"error,omitempty"`
+}
+
+// ClientConfig holds the configuration needed to create a Client.
+type ClientConfig struct {
+	APIKey  string
+	BaseURL string // Base URL including /v1 path (e.g., "https://api.openai.com/v1")
+	Timeout time.Duration
+}
+
+// Client is a minimal OpenAI Chat Completions client.
+type Client struct {
+	cfg        ClientConfig
+	httpClient *http.Client
+}
+
+// NewClient creates a new LLM client using the given config.
+func NewClient(cfg ClientConfig) *Client {
+	timeout := cfg.Timeout
+	if timeout == 0 {
+		timeout = 60 * time.Second
+	}
+
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = "https://api.openai.com/v1"
+	}
+	baseURL = strings.TrimSuffix(baseURL, "/")
+
+	return &Client{
+		cfg: ClientConfig{
+			APIKey:  cfg.APIKey,
+			BaseURL: baseURL,
+			Timeout: timeout,
+		},
+		httpClient: &http.Client{Timeout: timeout},
+	}
+}
+
+// Chat sends a chat completion request and returns the response.
+func (c *Client) Chat(ctx context.Context, req ChatRequest) (*ChatResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.cfg.BaseURL+"/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+c.cfg.APIKey)
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("http request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var chatResp ChatResponse
+	if err := json.Unmarshal(respBody, &chatResp); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	if chatResp.Error != nil {
+		return nil, fmt.Errorf("API error: %s", chatResp.Error.Message)
+	}
+
+	if len(chatResp.Choices) == 0 {
+		return nil, fmt.Errorf("no choices in response")
+	}
+
+	return &chatResp, nil
+}

--- a/internal/services/similar_artists.go
+++ b/internal/services/similar_artists.go
@@ -7,9 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
-	"net/http"
 	"os"
 	"strings"
 	"text/template"
@@ -21,6 +19,7 @@ import (
 	"spotter/ent/user"
 	"spotter/internal/config"
 	"spotter/internal/events"
+	"spotter/internal/llm"
 )
 
 const (
@@ -35,12 +34,12 @@ const (
 
 // SimilarArtistsService handles finding and storing similar artist relationships.
 type SimilarArtistsService struct {
-	client     *ent.Client
-	config     *config.Config
-	logger     *slog.Logger
-	bus        *events.Bus
-	httpClient *http.Client
-	templates  *template.Template
+	client    *ent.Client
+	config    *config.Config
+	logger    *slog.Logger
+	bus       *events.Bus
+	llm       *llm.Client
+	templates *template.Template
 }
 
 // NewSimilarArtistsService creates a new SimilarArtistsService.
@@ -54,9 +53,11 @@ func NewSimilarArtistsService(client *ent.Client, cfg *config.Config, logger *sl
 		config: cfg,
 		logger: logger,
 		bus:    bus,
-		httpClient: &http.Client{
+		llm: llm.NewClient(llm.ClientConfig{
+			APIKey:  cfg.OpenAI.APIKey,
+			BaseURL: cfg.OpenAI.BaseURL,
 			Timeout: defaultSimilarArtistsTimeout,
-		},
+		}),
 	}
 
 	// Load templates
@@ -257,39 +258,6 @@ func (s *SimilarArtistsService) fallbackPrompt(data SimilarArtistTemplateData) s
 	return sb.String()
 }
 
-// ChatMessage represents a message in the OpenAI chat format.
-type similarArtistChatMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
-}
-
-// ResponseFormat specifies the format of the response from OpenAI.
-type similarArtistResponseFormat struct {
-	Type string `json:"type"`
-}
-
-// ChatRequest represents a request to the OpenAI chat API.
-type similarArtistChatRequest struct {
-	Model          string                       `json:"model"`
-	Messages       []similarArtistChatMessage   `json:"messages"`
-	MaxTokens      int                          `json:"max_tokens"`
-	Temperature    float64                      `json:"temperature"`
-	ResponseFormat *similarArtistResponseFormat `json:"response_format,omitempty"`
-}
-
-// ChatResponse represents a response from the OpenAI chat API.
-type similarArtistChatResponse struct {
-	Choices []struct {
-		Message struct {
-			Content string `json:"content"`
-		} `json:"message"`
-	} `json:"choices"`
-	Error *struct {
-		Message string `json:"message"`
-		Type    string `json:"type"`
-	} `json:"error"`
-}
-
 // callOpenAI sends the prompt to OpenAI and returns the response.
 func (s *SimilarArtistsService) callOpenAI(ctx context.Context, prompt string) (string, error) {
 	if s.config.OpenAI.APIKey == "" {
@@ -297,65 +265,24 @@ func (s *SimilarArtistsService) callOpenAI(ctx context.Context, prompt string) (
 	}
 
 	model := s.config.GetVibesModel()
-	reqBody := similarArtistChatRequest{
+	req := llm.ChatRequest{
 		Model: model,
-		Messages: []similarArtistChatMessage{
+		Messages: []llm.ChatMessage{
 			{Role: "user", Content: prompt},
 		},
 		MaxTokens:   2000,
 		Temperature: 0.7,
-		ResponseFormat: &similarArtistResponseFormat{
+		ResponseFormat: &llm.ResponseFormat{
 			Type: "json_object",
 		},
 	}
 
-	jsonBody, err := json.Marshal(reqBody)
+	resp, err := s.llm.Chat(ctx, req)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal request: %w", err)
+		return "", err
 	}
 
-	baseURL := s.config.OpenAI.BaseURL
-	if baseURL == "" {
-		baseURL = "https://api.openai.com/v1"
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "POST", baseURL+"/chat/completions", bytes.NewReader(jsonBody))
-	if err != nil {
-		return "", fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+s.config.OpenAI.APIKey)
-
-	resp, err := s.httpClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("request failed: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("failed to read response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
-	}
-
-	var chatResp similarArtistChatResponse
-	if err := json.Unmarshal(body, &chatResp); err != nil {
-		return "", fmt.Errorf("failed to unmarshal response: %w", err)
-	}
-
-	if chatResp.Error != nil {
-		return "", fmt.Errorf("API error: %s", chatResp.Error.Message)
-	}
-
-	if len(chatResp.Choices) == 0 {
-		return "", fmt.Errorf("no response choices returned")
-	}
-
-	return chatResp.Choices[0].Message.Content, nil
+	return resp.Choices[0].Message.Content, nil
 }
 
 // parseJSONFromResponse extracts and parses JSON from the AI response.

--- a/internal/vibes/enhancer.go
+++ b/internal/vibes/enhancer.go
@@ -6,9 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
-	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -25,22 +23,23 @@ import (
 	"spotter/ent/user"
 	"spotter/internal/config"
 	"spotter/internal/events"
+	"spotter/internal/llm"
 )
 
 // PlaylistEnhancer implements playlist enhancement using AI.
 type PlaylistEnhancer struct {
-	client     *ent.Client
-	config     *config.Config
-	logger     *slog.Logger
-	bus        *events.Bus
-	httpClient *http.Client
-	templates  map[string]*template.Template
+	client    *ent.Client
+	config    *config.Config
+	logger    *slog.Logger
+	bus       *events.Bus
+	llm       *llm.Client
+	templates map[string]*template.Template
 }
 
 // NewPlaylistEnhancer creates a new PlaylistEnhancer service.
 func NewPlaylistEnhancer(client *ent.Client, cfg *config.Config, logger *slog.Logger, bus *events.Bus) *PlaylistEnhancer {
 	if logger == nil {
-		logger = slog.New(nopHandler{})
+		logger = slog.New(slog.DiscardHandler)
 	}
 
 	timeout := time.Duration(cfg.Vibes.TimeoutSeconds) * time.Second
@@ -53,9 +52,11 @@ func NewPlaylistEnhancer(client *ent.Client, cfg *config.Config, logger *slog.Lo
 		config: cfg,
 		logger: logger,
 		bus:    bus,
-		httpClient: &http.Client{
+		llm: llm.NewClient(llm.ClientConfig{
+			APIKey:  cfg.OpenAI.APIKey,
+			BaseURL: cfg.OpenAI.BaseURL,
 			Timeout: timeout,
-		},
+		}),
 		templates: make(map[string]*template.Template),
 	}
 
@@ -492,62 +493,32 @@ func (e *PlaylistEnhancer) fallbackPrompt(data *EnhancementTemplateData) string 
 
 // callOpenAI calls the OpenAI API with the prompt.
 func (e *PlaylistEnhancer) callOpenAI(ctx context.Context, prompt string) (string, int, error) {
-	reqBody := ChatRequest{
+	req := llm.ChatRequest{
 		Model: e.config.GetVibesModel(),
-		Messages: []ChatMessage{
+		Messages: []llm.ChatMessage{
 			{Role: "user", Content: prompt},
 		},
 		MaxTokens:   e.config.Vibes.MaxTokens,
 		Temperature: e.config.Vibes.Temperature,
-		ResponseFormat: &ResponseFormat{
+		ResponseFormat: &llm.ResponseFormat{
 			Type: "json_object",
 		},
 	}
 
-	jsonBody, err := json.Marshal(reqBody)
-	if err != nil {
-		return "", 0, fmt.Errorf("failed to marshal request: %w", err)
-	}
-
-	apiURL := fmt.Sprintf("%s/chat/completions", strings.TrimSuffix(e.config.OpenAI.BaseURL, "/"))
-	req, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(jsonBody))
-	if err != nil {
-		return "", 0, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+e.config.OpenAI.APIKey)
-
-	resp, err := e.httpClient.Do(req)
+	resp, err := e.llm.Chat(ctx, req)
 	if err != nil {
 		return "", 0, fmt.Errorf("failed to execute request: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", 0, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		var errorResp ChatResponse
-		if json.Unmarshal(body, &errorResp) == nil && errorResp.Error.Message != "" {
-			return "", 0, fmt.Errorf("API error: %s", errorResp.Error.Message)
-		}
-		return "", 0, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
-	}
-
-	var chatResp ChatResponse
-	if err := json.Unmarshal(body, &chatResp); err != nil {
-		return "", 0, fmt.Errorf("failed to parse response: %w", err)
-	}
-
-	if len(chatResp.Choices) == 0 {
+	if len(resp.Choices) == 0 {
 		return "", 0, fmt.Errorf("no response from AI")
 	}
 
-	content := chatResp.Choices[0].Message.Content
-	tokensUsed := chatResp.Usage.TotalTokens
+	content := resp.Choices[0].Message.Content
+	tokensUsed := 0
+	if resp.Usage != nil {
+		tokensUsed = resp.Usage.TotalTokens
+	}
 
 	return content, tokensUsed, nil
 }

--- a/internal/vibes/enhancer_test.go
+++ b/internal/vibes/enhancer_test.go
@@ -10,6 +10,7 @@ import (
 	"spotter/ent/enttest"
 	"spotter/internal/config"
 	"spotter/internal/events"
+	"spotter/internal/llm"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
@@ -33,7 +34,7 @@ func TestNewPlaylistEnhancer(t *testing.T) {
 
 	enhancer := NewPlaylistEnhancer(client, cfg, nil, bus)
 	assert.NotNil(t, enhancer)
-	assert.NotNil(t, enhancer.httpClient)
+	assert.NotNil(t, enhancer.llm)
 	assert.NotNil(t, enhancer.templates)
 }
 
@@ -492,19 +493,12 @@ func TestEnhancePlaylist_Success(t *testing.T) {
 
 	// Mock OpenAI server
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := ChatResponse{
+		resp := llm.ChatResponse{
 			ID:      "test-id",
 			Object:  "chat.completion",
 			Created: 1234567890,
 			Model:   "gpt-4o",
-			Choices: []struct {
-				Index   int `json:"index"`
-				Message struct {
-					Role    string `json:"role"`
-					Content string `json:"content"`
-				} `json:"message"`
-				FinishReason string `json:"finish_reason"`
-			}{
+			Choices: []llm.ChatChoice{
 				{
 					Index: 0,
 					Message: struct {
@@ -525,11 +519,7 @@ func TestEnhancePlaylist_Success(t *testing.T) {
 					FinishReason: "stop",
 				},
 			},
-			Usage: &struct {
-				PromptTokens     int `json:"prompt_tokens"`
-				CompletionTokens int `json:"completion_tokens"`
-				TotalTokens      int `json:"total_tokens"`
-			}{
+			Usage: &llm.ChatUsage{
 				PromptTokens:     100,
 				CompletionTokens: 50,
 				TotalTokens:      150,

--- a/internal/vibes/generator.go
+++ b/internal/vibes/generator.go
@@ -6,9 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -23,6 +21,7 @@ import (
 	"spotter/ent/user"
 	"spotter/internal/config"
 	"spotter/internal/events"
+	"spotter/internal/llm"
 )
 
 // nopHandler is a slog handler that discards all log records.
@@ -35,12 +34,12 @@ func (h nopHandler) WithGroup(string) slog.Handler           { return h }
 
 // MixtapeGenerator implements the Generator interface for creating AI-powered mixtapes.
 type MixtapeGenerator struct {
-	client     *ent.Client
-	config     *config.Config
-	logger     *slog.Logger
-	bus        *events.Bus
-	httpClient *http.Client
-	templates  map[string]*template.Template
+	client    *ent.Client
+	config    *config.Config
+	logger    *slog.Logger
+	bus       *events.Bus
+	llm       *llm.Client
+	templates map[string]*template.Template
 }
 
 // NewMixtapeGenerator creates a new MixtapeGenerator service.
@@ -62,9 +61,11 @@ func NewMixtapeGenerator(client *ent.Client, cfg *config.Config, logger *slog.Lo
 		config: cfg,
 		logger: logger,
 		bus:    bus,
-		httpClient: &http.Client{
+		llm: llm.NewClient(llm.ClientConfig{
+			APIKey:  cfg.OpenAI.APIKey,
+			BaseURL: cfg.OpenAI.BaseURL,
 			Timeout: timeout,
-		},
+		}),
 		templates: make(map[string]*template.Template),
 	}
 
@@ -606,60 +607,8 @@ func (g *MixtapeGenerator) fallbackPrompt(data *TemplateData) string {
 	return sb.String()
 }
 
-// ChatMessage represents a message in the OpenAI chat format.
-type ChatMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
-}
-
-// ResponseFormat specifies the format of the response from OpenAI.
-type ResponseFormat struct {
-	Type string `json:"type"`
-}
-
-// ChatRequest represents an OpenAI chat completion request.
-type ChatRequest struct {
-	Model          string          `json:"model"`
-	Messages       []ChatMessage   `json:"messages"`
-	MaxTokens      int             `json:"max_tokens,omitempty"`
-	Temperature    float64         `json:"temperature,omitempty"`
-	ResponseFormat *ResponseFormat `json:"response_format,omitempty"`
-}
-
-// ChatResponse represents an OpenAI chat completion response.
-type ChatResponse struct {
-	ID      string `json:"id"`
-	Object  string `json:"object"`
-	Created int64  `json:"created"`
-	Model   string `json:"model"`
-	Choices []struct {
-		Index   int `json:"index"`
-		Message struct {
-			Role    string `json:"role"`
-			Content string `json:"content"`
-		} `json:"message"`
-		FinishReason string `json:"finish_reason"`
-	} `json:"choices"`
-	Usage *struct {
-		PromptTokens     int `json:"prompt_tokens"`
-		CompletionTokens int `json:"completion_tokens"`
-		TotalTokens      int `json:"total_tokens"`
-	} `json:"usage"`
-	Error *struct {
-		Message string `json:"message"`
-		Type    string `json:"type"`
-		Code    string `json:"code"`
-	} `json:"error"`
-}
-
 // callOpenAI makes a request to the OpenAI API.
 func (g *MixtapeGenerator) callOpenAI(ctx context.Context, prompt string) (string, int, error) {
-	baseURL := g.config.OpenAI.BaseURL
-	if baseURL == "" {
-		baseURL = "https://api.openai.com/v1"
-	}
-	baseURL = strings.TrimSuffix(baseURL, "/")
-
 	model := g.config.GetVibesModel()
 	temperature := g.config.Vibes.Temperature
 	if temperature <= 0 {
@@ -671,15 +620,14 @@ func (g *MixtapeGenerator) callOpenAI(ctx context.Context, prompt string) (strin
 	}
 
 	g.logger.Debug("preparing OpenAI request",
-		"base_url", baseURL,
 		"model", model,
 		"temperature", temperature,
 		"max_tokens", maxTokens,
 		"prompt_length", len(prompt))
 
-	req := ChatRequest{
+	req := llm.ChatRequest{
 		Model: model,
-		Messages: []ChatMessage{
+		Messages: []llm.ChatMessage{
 			{
 				Role:    "user",
 				Content: prompt,
@@ -687,72 +635,27 @@ func (g *MixtapeGenerator) callOpenAI(ctx context.Context, prompt string) (strin
 		},
 		MaxTokens:   maxTokens,
 		Temperature: temperature,
-		ResponseFormat: &ResponseFormat{
+		ResponseFormat: &llm.ResponseFormat{
 			Type: "json_object",
 		},
 	}
 
-	reqBody, err := json.Marshal(req)
-	if err != nil {
-		return "", 0, fmt.Errorf("failed to marshal request: %w", err)
-	}
-
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", baseURL+"/chat/completions", bytes.NewReader(reqBody))
-	if err != nil {
-		return "", 0, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+g.config.OpenAI.APIKey)
-
-	g.logger.Debug("sending OpenAI request", "url", baseURL+"/chat/completions")
-
-	resp, err := g.httpClient.Do(httpReq)
+	resp, err := g.llm.Chat(ctx, req)
 	if err != nil {
 		g.logger.Error("OpenAI request failed", "error", err)
 		return "", 0, fmt.Errorf("request failed: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", 0, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	g.logger.Debug("received OpenAI response",
-		"status", resp.StatusCode,
-		"body_length", len(body))
-
-	if resp.StatusCode != http.StatusOK {
-		g.logger.Error("OpenAI API error",
-			"status", resp.StatusCode,
-			"body", string(body))
-		return "", 0, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
-	}
-
-	var chatResp ChatResponse
-	if err := json.Unmarshal(body, &chatResp); err != nil {
-		return "", 0, fmt.Errorf("failed to parse response: %w", err)
-	}
-
-	if chatResp.Error != nil {
-		return "", 0, fmt.Errorf("API error: %s", chatResp.Error.Message)
-	}
-
-	if len(chatResp.Choices) == 0 {
-		return "", 0, fmt.Errorf("no choices in response")
-	}
 
 	tokensUsed := 0
-	if chatResp.Usage != nil {
-		tokensUsed = chatResp.Usage.TotalTokens
+	if resp.Usage != nil {
+		tokensUsed = resp.Usage.TotalTokens
 		g.logger.Info("OpenAI token usage",
-			"prompt_tokens", chatResp.Usage.PromptTokens,
-			"completion_tokens", chatResp.Usage.CompletionTokens,
-			"total_tokens", chatResp.Usage.TotalTokens)
+			"prompt_tokens", resp.Usage.PromptTokens,
+			"completion_tokens", resp.Usage.CompletionTokens,
+			"total_tokens", resp.Usage.TotalTokens)
 	}
 
-	return chatResp.Choices[0].Message.Content, tokensUsed, nil
+	return resp.Choices[0].Message.Content, tokensUsed, nil
 }
 
 // parseAIResponse parses the AI response JSON.

--- a/internal/vibes/generator_test.go
+++ b/internal/vibes/generator_test.go
@@ -11,6 +11,7 @@ import (
 	"spotter/ent/enttest"
 	"spotter/internal/config"
 	"spotter/internal/events"
+	"spotter/internal/llm"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
@@ -573,19 +574,12 @@ func TestMixtapeGenerator_MatchTracksToLibrary(t *testing.T) {
 
 func TestMixtapeGenerator_Integration(t *testing.T) {
 	// Create a mock OpenAI server
-	mockResponse := ChatResponse{
+	mockResponse := llm.ChatResponse{
 		ID:      "test-id",
 		Object:  "chat.completion",
 		Created: 1234567890,
 		Model:   "gpt-4o",
-		Choices: []struct {
-			Index   int `json:"index"`
-			Message struct {
-				Role    string `json:"role"`
-				Content string `json:"content"`
-			} `json:"message"`
-			FinishReason string `json:"finish_reason"`
-		}{
+		Choices: []llm.ChatChoice{
 			{
 				Index: 0,
 				Message: struct {
@@ -605,11 +599,7 @@ func TestMixtapeGenerator_Integration(t *testing.T) {
 				FinishReason: "stop",
 			},
 		},
-		Usage: &struct {
-			PromptTokens     int `json:"prompt_tokens"`
-			CompletionTokens int `json:"completion_tokens"`
-			TotalTokens      int `json:"total_tokens"`
-		}{
+		Usage: &llm.ChatUsage{
 			PromptTokens:     100,
 			CompletionTokens: 50,
 			TotalTokens:      150,


### PR DESCRIPTION
## Summary

- Creates `internal/llm/client.go` with shared `ChatRequest`, `ChatResponse`, `ChatChoice`, `ChatUsage`, `ContentPart`, `ImageURL`, `ResponseFormat` types and `Client.Chat()` method
- Migrates `internal/services/similar_artists.go` to use the shared client
- Migrates `internal/enrichers/openai/openai.go` to use the shared client (including multi-modal/image support via `ContentPart`)
- Migrates `internal/vibes/generator.go` to use the shared client
- Migrates `internal/vibes/enhancer.go` to use the shared client
- Updates all associated test files to use `llm.ChatResponse` and `llm.ChatChoice`
- Net reduction: 258 lines added, 439 lines removed (-181 lines)

## Motivation

`ChatRequest`/`ChatResponse` and `callOpenAI()` HTTP logic were duplicated across 4 packages. Bug fixes or API changes must now only be applied once in `internal/llm/client.go`.

## Test Plan
- [x] `go build ./internal/llm/... ./internal/vibes/... ./internal/services/... ./internal/enrichers/openai/...` passes
- [x] `go vet` passes on all modified packages
- [x] All existing tests pass (`go test` on all modified packages)
- [ ] Similar artists still generates recommendations
- [ ] Enricher still enriches artists/albums/tracks
- [ ] Vibes mixtape generation still works

Closes #119