### PR TITLE
Event Bus: Typed events, SSE endpoint, and HTMX integration (#198, #204, #211)

### DIFF
--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 )
 
+// Governing: SPEC event-bus-sse REQ-BUS-011 (EventType string constants)
 type EventType string
 
 const (
@@ -29,11 +30,13 @@ const (
 	EventTypeSimilarArtistsError     EventType = "similar-artists-error"
 )
 
+// Governing: SPEC event-bus-sse REQ-BUS-010 (Event struct with Type and Payload)
 type Event struct {
 	Type    EventType
 	Payload any
 }
 
+// Governing: SPEC event-bus-sse REQ-BUS-012 (typed payload structs), REQ-BUS-013 (IconType field)
 type NotificationPayload struct {
 	Title    string
 	Message  string

--- a/internal/handlers/sse.go
+++ b/internal/handlers/sse.go
@@ -1,4 +1,4 @@
-// Governing: ADR-0007 (in-memory event bus), SPEC event-bus-sse
+// Governing: ADR-0007 (in-memory event bus), ADR-0001 (HTMX+Templ), SPEC event-bus-sse REQ-SSE-001 through REQ-SSE-005
 package handlers
 
 import (
@@ -11,6 +11,10 @@ import (
 	"spotter/internal/views/components"
 )
 
+// Events serves the SSE endpoint for real-time event streaming.
+// Governing: SPEC event-bus-sse REQ-SSE-001 (auth-gated SSE endpoint with required headers)
+// Governing: SPEC event-bus-sse REQ-SSE-003 (http.Flusher check, 500 if unsupported)
+// Governing: SPEC event-bus-sse REQ-SSE-004 (context cancellation for client disconnect)
 func (h *Handler) Events(w http.ResponseWriter, r *http.Request) {
 	u := h.GetUser(r.Context())
 	if u == nil {
@@ -173,6 +177,7 @@ func (h *Handler) Events(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 
+			// Governing: SPEC event-bus-sse REQ-SSE-002 (render to HTML fragment), REQ-SSE-005 (named event field)
 			if buf.Len() > 0 {
 				if _, err := fmt.Fprintf(w, "event: %s\n", event.Type); err != nil {
 					h.Logger.Error("failed to write SSE event type", "error", err)

--- a/internal/views/components/toast.templ
+++ b/internal/views/components/toast.templ
@@ -76,6 +76,7 @@ templ Toast(title, message, iconType string) {
 	@initToast(id)
 }
 
+// Governing: SPEC event-bus-sse REQ-SSE-012 (sse-swap="notification" with hx-swap for DOM swapping)
 templ ToastContainer() {
 	<div
 		id="toasts"

--- a/internal/views/layouts/base.templ
+++ b/internal/views/layouts/base.templ
@@ -20,6 +20,7 @@ templ BaseWithTheme(title string, defaultTheme string) {
 			<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 			<title>{ title }</title>
 			<script src="https://unpkg.com/htmx.org@1.9.10"></script>
+			<!-- Governing: SPEC event-bus-sse REQ-SSE-010 (load HTMX SSE extension) -->
 			<script src="https://unpkg.com/htmx.org@1.9.10/dist/ext/sse.js"></script>
 			// Hyperscript: required for _="..." attributes in create_mixtape_modal, enhance_vibes_modal
 			<script src="https://unpkg.com/hyperscript.org@0.9.12"></script>

--- a/internal/views/layouts/dashboard.templ
+++ b/internal/views/layouts/dashboard.templ
@@ -34,6 +34,7 @@ func isVibesSection(currentPath string) bool {
 
 templ Dashboard(title string, cfg *config.Config, currentPath string) {
 	@BaseWithTheme(title, cfg.Theme.Default) {
+		<!-- Governing: SPEC event-bus-sse REQ-SSE-011 (hx-ext="sse" and sse-connect="/events") -->
 		<div class="drawer lg:drawer-open" hx-ext="sse" sse-connect="/events">
 			<input id="drawer-toggle" type="checkbox" class="drawer-toggle"/>
 			<!-- Main Content -->


### PR DESCRIPTION
## Summary

Verifies spec compliance for event types, SSE streaming, and HTMX integration.

All requirements were already fully implemented. This PR adds 12 governing comment lines across 5 files tracing the implementation back to the governing spec (no logic changes). Queue exhausted — no further issues to bundle.

**Files changed:**
- `internal/events/bus.go`: +3 governing comments (REQ-BUS-010, REQ-BUS-011, REQ-BUS-012/013)
- `internal/handlers/sse.go`: +6 governing comments (REQ-SSE-001 through REQ-SSE-005)
- `internal/views/layouts/base.templ`: +1 governing comment (REQ-SSE-010)
- `internal/views/layouts/dashboard.templ`: +1 governing comment (REQ-SSE-011)
- `internal/views/components/toast.templ`: +1 governing comment (REQ-SSE-012)

## Test plan

- [x] Verified all 14 requirements (REQ-BUS-010 through REQ-SSE-012) satisfied by existing code
- [x] `go build ./internal/events/...` and `go vet ./internal/events/...` pass
- [x] Changes are governing comments only — no logic modifications

Closes #198
Closes #204
Closes #211
Part of epic #187
Governing: event-bus-sse spec REQ-BUS-010 through REQ-SSE-012, ADR-0007, ADR-0001

🤖 Generated with [Claude Code](https://claude.com/claude-code)