### PR TITLE
Listen Sync: Verify all sync stories (#232-235)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -97,6 +97,7 @@ func main() {
 	// Initialize Event Bus
 	bus := events.NewBus()
 
+	// Governing: ADR-0016 (pluggable provider factory), SPEC listen-playlist-sync REQ-SYNC-001 (factory registration at startup)
 	// Initialize Sync Service (for playlists and listens)
 	syncer := services.NewSyncer(client, cfg, logger, bus)
 	syncer.Register(navidrome.New(logger, cfg))
@@ -164,6 +165,8 @@ func main() {
 	// Governing: SPEC graceful-shutdown REQ-WG-001 (single shared WaitGroup for all per-user goroutines)
 	var wg sync.WaitGroup
 
+	// Governing: ADR-0013 (goroutine ticker scheduling), SPEC listen-playlist-sync REQ-SYNC-040 (configurable ticker interval)
+	// Governing: SPEC listen-playlist-sync REQ-SYNC-041 (per-user goroutines for parallel sync)
 	// Background Sync Loop for listens/playlists
 	syncInterval, err := time.ParseDuration(cfg.Sync.Interval)
 	if err != nil {

--- a/internal/handlers/preferences.go
+++ b/internal/handlers/preferences.go
@@ -166,6 +166,7 @@ func (h *Handler) DisconnectLastFM(w http.ResponseWriter, r *http.Request) {
 
 // SyncNavidrome triggers a sync for Navidrome data
 // Governing: SPEC graceful-shutdown REQ "background goroutines must not capture *ent.User pointer"
+// Governing: SPEC listen-playlist-sync REQ-SYNC-050 (on-demand sync via HTTP), REQ-SYNC-051 (returns immediately, sync in background)
 func (h *Handler) SyncNavidrome(w http.ResponseWriter, r *http.Request) {
 	u := h.GetUser(r.Context())
 	if u == nil {
@@ -694,6 +695,7 @@ func (h *Handler) getTasksWithLastRun(ctx context.Context, u *ent.User) []types.
 
 // TaskSyncListens triggers a sync of all listens
 // Governing: SPEC graceful-shutdown REQ "background goroutines must not capture *ent.User pointer"
+// Governing: SPEC listen-playlist-sync REQ-SYNC-050 (on-demand sync via HTTP), REQ-SYNC-051 (returns immediately, sync in background)
 func (h *Handler) TaskSyncListens(w http.ResponseWriter, r *http.Request) {
 	u := h.GetUser(r.Context())
 	if u == nil {
@@ -726,6 +728,7 @@ func (h *Handler) TaskSyncListens(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+// Governing: SPEC listen-playlist-sync REQ-SYNC-050 (on-demand sync via HTTP), REQ-SYNC-051 (returns immediately, sync in background)
 // TaskSyncPlaylists triggers a sync of all playlists
 // Governing: SPEC graceful-shutdown REQ "background goroutines must not capture *ent.User pointer"
 func (h *Handler) TaskSyncPlaylists(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/lastfm/lastfm.go
+++ b/internal/providers/lastfm/lastfm.go
@@ -38,6 +38,7 @@ type Provider struct {
 var _ providers.HistoryFetcher = (*Provider)(nil)
 var _ providers.Authenticator = (*Provider)(nil)
 
+// Governing: ADR-0016 (pluggable provider factory), SPEC listen-playlist-sync REQ-SYNC-002 (factory returns nil if unconfigured)
 // New returns a factory that creates Last.fm providers for a given user.
 func New(logger *slog.Logger, cfg *config.Config) providers.Factory {
 	return func(ctx context.Context, user *ent.User) (providers.Provider, error) {

--- a/internal/providers/navidrome/navidrome.go
+++ b/internal/providers/navidrome/navidrome.go
@@ -38,6 +38,7 @@ var _ providers.PlaylistManager = (*Provider)(nil)
 var _ providers.Authenticator = (*Provider)(nil)
 var _ providers.PlaylistSyncer = (*Provider)(nil)
 
+// Governing: ADR-0016 (pluggable provider factory), SPEC listen-playlist-sync REQ-SYNC-002 (factory returns nil if unconfigured)
 // New returns a factory that creates Navidrome providers for a given user.
 func New(logger *slog.Logger, cfg *config.Config) providers.Factory {
 	return func(ctx context.Context, user *ent.User) (providers.Provider, error) {

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -120,6 +120,7 @@ type Authenticator interface {
 	Disconnect(ctx context.Context) error
 }
 
+// Governing: ADR-0016 (pluggable provider factory), SPEC listen-playlist-sync REQ-SYNC-001, REQ-SYNC-002
 // Factory defines the function signature for creating a provider instance for a specific user.
 // Implementations should return nil, nil if the user is not configured for the provider.
 type Factory func(ctx context.Context, user *ent.User) (Provider, error)

--- a/internal/providers/spotify/spotify.go
+++ b/internal/providers/spotify/spotify.go
@@ -39,6 +39,7 @@ var _ providers.HistoryFetcher = (*Provider)(nil)
 var _ providers.PlaylistManager = (*Provider)(nil)
 var _ providers.Authenticator = (*Provider)(nil)
 
+// Governing: ADR-0016 (pluggable provider factory), SPEC listen-playlist-sync REQ-SYNC-002 (factory returns nil if unconfigured)
 // New returns a factory that creates Spotify providers for a given user.
 func New(logger *slog.Logger, cfg *config.Config) providers.Factory {
 	return func(ctx context.Context, user *ent.User) (providers.Provider, error) {

--- a/internal/services/sync.go
+++ b/internal/services/sync.go
@@ -40,6 +40,7 @@ func NewSyncer(client *ent.Client, cfg *config.Config, logger *slog.Logger, bus 
 	}
 }
 
+// Governing: ADR-0016 (pluggable provider factory), SPEC listen-playlist-sync REQ-SYNC-001
 // Register adds a new provider factory to the syncer.
 func (s *Syncer) Register(factory providers.Factory) {
 	s.Factories = append(s.Factories, factory)
@@ -47,6 +48,8 @@ func (s *Syncer) Register(factory providers.Factory) {
 
 // Governing: ADR-0019 (structured metrics), SPEC observability REQ "BG-003"
 // Governing: SPEC graceful-shutdown REQ-REC-004 (ctx propagated to DB ops; cancellation leaves DB consistent)
+// Governing: SPEC listen-playlist-sync REQ-SYNC-010 (full sync: providers -> history -> playlists)
+// Governing: SPEC listen-playlist-sync REQ-SYNC-011 (history failure does not abort playlist sync)
 // Sync performs a full synchronization (history and playlists) for the user.
 func (s *Syncer) Sync(ctx context.Context, u *ent.User) error {
 	s.Logger.Info("starting full sync", "username", u.Username)
@@ -150,6 +153,7 @@ func (s *Syncer) SyncPlaylists(ctx context.Context, u *ent.User) error {
 	return err
 }
 
+// Governing: SPEC listen-playlist-sync REQ-SYNC-002 (nil factories silently skipped), REQ-SYNC-003 (factory errors logged and skipped)
 // getActiveProviders returns the refreshed user with all auth edges loaded and a list of active providers.
 func (s *Syncer) getActiveProviders(ctx context.Context, u *ent.User) (*ent.User, []providers.Provider, error) {
 	// Refresh user to ensure we have all auth edges loaded so factories can check configuration.
@@ -197,6 +201,9 @@ func (s *Syncer) logEvent(ctx context.Context, u *ent.User, eventType syncevent.
 	}
 }
 
+// Governing: SPEC listen-playlist-sync REQ-SYNC-020 (since timestamp from last listen)
+// Governing: SPEC listen-playlist-sync REQ-SYNC-022 (per-track errors logged, sync continues)
+// Governing: SPEC listen-playlist-sync REQ-SYNC-023 (notification published on new listens)
 func (s *Syncer) syncHistory(ctx context.Context, u *ent.User, activeProviders []providers.Provider) (int, error) {
 	allAdded := 0
 	for _, provider := range activeProviders {
@@ -331,6 +338,7 @@ func (s *Syncer) syncHistory(ctx context.Context, u *ent.User, activeProviders [
 	return allAdded, nil
 }
 
+// Governing: SPEC listen-playlist-sync REQ-SYNC-030 (fetch playlists from each PlaylistManager provider)
 func (s *Syncer) syncPlaylists(ctx context.Context, u *ent.User, activeProviders []providers.Provider) (int, error) {
 	allAdded := 0
 	for _, provider := range activeProviders {
@@ -450,6 +458,7 @@ func (s *Syncer) publishFatalNotification(userID int, key BackoffKey, providerNa
 	s.Backoff.MarkNotified(key)
 }
 
+// Governing: SPEC listen-playlist-sync REQ-SYNC-021 (upsert Listen with dedup by provider+track+played_at)
 func (s *Syncer) persistListens(ctx context.Context, u *ent.User, source providers.Type, tracks []providers.Track) (int, int, error) {
 	savedCount := 0
 	skippedCount := 0
@@ -567,6 +576,7 @@ func (s *Syncer) isDuplicateListen(ctx context.Context, u *ent.User, track provi
 	return exists
 }
 
+// Governing: SPEC listen-playlist-sync REQ-SYNC-012 (sync cursor updated after each provider sync)
 func (s *Syncer) updateLastSyncedAt(ctx context.Context, u *ent.User, providerType providers.Type) error {
 	now := time.Now()
 	switch providerType {
@@ -586,6 +596,7 @@ func (s *Syncer) updateLastSyncedAt(ctx context.Context, u *ent.User, providerTy
 	return nil
 }
 
+// Governing: SPEC listen-playlist-sync REQ-SYNC-031 (upsert Playlist by source+remoteID)
 func (s *Syncer) persistPlaylists(ctx context.Context, u *ent.User, source providers.Type, playlists []providers.Playlist) (int, int, error) {
 	addedCount := 0
 	updatedCount := 0
@@ -711,6 +722,7 @@ func (s *Syncer) persistPlaylists(ctx context.Context, u *ent.User, source provi
 	return addedCount, updatedCount, nil
 }
 
+// Governing: SPEC listen-playlist-sync REQ-SYNC-031 (upsert PlaylistTrack with position), REQ-SYNC-032 (removed tracks deleted)
 // persistPlaylistTracks saves tracks for a playlist, upserting to preserve catalog links
 func (s *Syncer) persistPlaylistTracks(ctx context.Context, playlistID int, tracks []providers.Track) error {
 	// Get the playlist to access user and provider info


### PR DESCRIPTION
## Summary

Verifies spec compliance across all four listen/playlist sync stories in epic #231. All requirements were already fully implemented -- this PR adds governing comments to trace implementation back to spec requirements.

- **#232 Provider Registration & Factory Pattern**: REQ-SYNC-001 through REQ-SYNC-003 verified across `internal/providers/`, `internal/services/sync.go`, and `cmd/server/main.go`
- **#233 History Synchronization & Listen Import**: REQ-SYNC-010 through REQ-SYNC-023 verified in `internal/services/sync.go`
- **#234 Playlist Synchronization & Cache Management**: REQ-SYNC-030 through REQ-SYNC-032, REQ-SYNC-012 verified in `internal/services/sync.go`
- **#235 Background Scheduling & On-Demand Sync**: REQ-SYNC-040 through REQ-SYNC-051 verified in `cmd/server/main.go` and `internal/handlers/preferences.go`

22 governing comments added across 7 files. No logic changes.

Closes #232
Closes #233
Closes #234
Closes #235
Part of epic #231
Governing: listen-playlist-sync spec REQ-SYNC-001 through REQ-SYNC-051, ADR-0016, ADR-0007, ADR-0005, ADR-0013

## Test plan

- [ ] Verify `go build ./...` passes (comment-only changes, no compilation impact)
- [ ] Confirm governing comments reference correct spec requirements
- [ ] Spot-check that each requirement maps to real code at the commented location

🤖 Generated with [Claude Code](https://claude.com/claude-code)