### PR TITLE
Error Handling: Verify backoff state, fatal notifications, and recovery

### DIFF
--- a/internal/services/sync.go
+++ b/internal/services/sync.go
@@ -284,8 +284,8 @@ func (s *Syncer) syncHistory(ctx context.Context, u *ent.User, activeProviders [
 				"error", err,
 				"error_class", errClass.String(),
 			)
-			// Publish fatal error notification
-			// Governing: SPEC error-handling REQ-NOTIFY-001, REQ-NOTIFY-002
+			// Publish fatal error notification (retriable errors do not trigger notifications)
+			// Governing: SPEC error-handling REQ-NOTIFY-001, REQ-NOTIFY-002, REQ-NOTIFY-003
 			if errClass == ErrorClassFatal {
 				s.publishFatalNotification(u.ID, backoffKey, providerName, err)
 			}
@@ -374,8 +374,8 @@ func (s *Syncer) syncPlaylists(ctx context.Context, u *ent.User, activeProviders
 				"error", err,
 				"error_class", errClass.String(),
 			)
-			// Publish fatal error notification
-			// Governing: SPEC error-handling REQ-NOTIFY-001, REQ-NOTIFY-002
+			// Publish fatal error notification (retriable errors do not trigger notifications)
+			// Governing: SPEC error-handling REQ-NOTIFY-001, REQ-NOTIFY-002, REQ-NOTIFY-003
 			if errClass == ErrorClassFatal {
 				s.publishFatalNotification(u.ID, backoffKey, providerName, err)
 			}
@@ -426,8 +426,8 @@ func (s *Syncer) syncPlaylists(ctx context.Context, u *ent.User, activeProviders
 }
 
 // publishFatalNotification publishes a user-visible notification for fatal provider errors.
-// It only publishes once per fatal error occurrence.
-// Governing: SPEC error-handling REQ-NOTIFY-001, REQ-NOTIFY-002
+// It only publishes once per fatal error occurrence. Only called for fatal errors (not retriable).
+// Governing: SPEC error-handling REQ-NOTIFY-001, REQ-NOTIFY-002, REQ-NOTIFY-003
 func (s *Syncer) publishFatalNotification(userID int, key BackoffKey, providerName string, err error) {
 	state, ok := s.Backoff.GetState(key)
 	if !ok || state.NotifiedFatal {


### PR DESCRIPTION
## Summary

Verifies spec compliance for the error handling resilience implementation across three issues:

- **#174 (Backoff State Management):** REQ-BACK-001 through REQ-BACK-004 and REQ-STATE-001 through REQ-STATE-003 — all implemented with governing comments in `resilience.go`
- **#177 (Fatal Errors and User Notification):** REQ-STATE-004, REQ-NOTIFY-001, REQ-NOTIFY-002, REQ-NOTIFY-003 — fatal notification path in `sync.go` with `publishFatalNotification()` and `notifiedFatal` dedup flag
- **#180 (Recovery and State Reset):** REQ-RECOVER-001, REQ-RECOVER-002 — `RecordSuccess()` atomically resets all state, called immediately after successful provider calls

Added missing `REQ-NOTIFY-003` governing comments to confirm retriable errors do not trigger user notifications. All other requirements were already fully implemented.

Closes #174
Closes #177
Closes #180
Part of epic #172
Governing: error-handling spec REQ-BACK-001 through REQ-RECOVER-002, ADR-0020, ADR-0007

## Test plan

- [x] All 30 resilience-related tests pass (`go test ./internal/services/... -run "TestBackoff|TestCalculateBackoff|TestClassifyError|TestErrorClass|TestHTTPStatus"`)
- [x] Verified each requirement maps to implementation code with governing comments
- [x] Confirmed `publishFatalNotification` is only called inside `if errClass == ErrorClassFatal` guard (REQ-NOTIFY-003)

🤖 Generated with [Claude Code](https://claude.com/claude-code)