### PR TITLE
Verify multi-database spec compliance and add governing comments

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -279,6 +279,7 @@ func setRequiredEnvVars(t *testing.T) {
 	t.Setenv("SPOTTER_SECURITY_JWT_SECRET", "test-jwt-secret-at-least-32-chars")
 }
 
+// Governing: SPEC-0014 REQ "Test Coverage" (valid drivers, invalid driver rejection, default source per driver)
 func TestConfig_ValidDrivers(t *testing.T) {
 	for _, driver := range []string{"sqlite3", "postgres", "mysql"} {
 		t.Run(driver, func(t *testing.T) {

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -24,7 +24,7 @@ func NewClient(driver, source string, encryptor *crypto.Encryptor) (*ent.Client,
 		RegisterEncryptionHooks(client, encryptor)
 	}
 
-	// Run the auto migration tool.
+	// Governing: SPEC-0014 REQ "Schema Migration", ADR-0004 (Ent ORM handles DDL for all dialects)
 	if err := client.Schema.Create(context.Background()); err != nil {
 		// Attempt to close the client on schema creation failure
 		_ = client.Close()


### PR DESCRIPTION
## Summary
- Added governing comment to `internal/database/db.go` for SPEC-0014 REQ "Schema Migration" on the `Schema.Create()` call
- Added governing comment to `internal/config/config_test.go` for SPEC-0014 REQ "Test Coverage" on the multi-driver test group

## Verification Summary

- **#224 (Driver Registration and Validation)**: `db.go` already had governing comment for REQ "Driver Registration". All three blank imports present (sqlite3, pq, mysql). `config.go` already had governing comment for REQ "Driver Validation". `go.mod` has all three driver dependencies. Added governing comment for REQ "Schema Migration".
- **#225 (Configuration and Schema Migration)**: `config.go` already had governing comment for REQ "Driver-Specific Default Source". `db.go` `Schema.Create()` handles all dialects per ADR-0004. Added governing comment.
- **#227 (Deployment Configuration and Documentation)**: Both docker-compose files already have governing comments for REQ "Docker Compose Examples". Health checks, `depends_on` conditions, named volumes all present. `website/docs/getting-started/configuration.md` and `docker.md` cover database configuration and deployment. No changes needed.
- **#228 (Test Coverage)**: `config_test.go` has `TestConfig_ValidDrivers`, `TestConfig_InvalidDriver`, `TestConfig_PostgresDefaultSource`, `TestConfig_MySQLDefaultSource` per spec. Added governing comment.

## Changes
- 2 lines changed (governing comments only, no logic changes)

Closes #224
Closes #225
Closes #227
Closes #228
Part of #223
Governing: SPEC-0014, ADR-0023

## Test plan
- [ ] Verify `go build ./...` passes (comment-only changes)
- [ ] Verify `go test ./internal/config/...` passes