### PR TITLE
Observability: extract token counts in SimilarArtistsService (#200)

### DIFF
--- a/internal/services/similar_artists.go
+++ b/internal/services/similar_artists.go
@@ -183,7 +183,7 @@ func (s *SimilarArtistsService) FindSimilarArtists(ctx context.Context, userID i
 	// Call OpenAI
 	model := s.config.GetVibesModel()
 	llmStart := time.Now()
-	response, err := s.callOpenAI(ctx, prompt)
+	response, tokensUsed, err := s.callOpenAI(ctx, prompt)
 	llmDuration := time.Since(llmStart).Milliseconds()
 	if err != nil {
 		s.logger.Info("metric.llm",
@@ -199,7 +199,7 @@ func (s *SimilarArtistsService) FindSimilarArtists(ctx context.Context, userID i
 	s.logger.Info("metric.llm",
 		"model", model,
 		"operation", "similar_artists",
-		"tokens_used", 0,
+		"tokens_used", tokensUsed,
 		"duration_ms", llmDuration,
 		"success", true,
 		"error", "")
@@ -264,10 +264,11 @@ func (s *SimilarArtistsService) fallbackPrompt(data SimilarArtistTemplateData) s
 
 // Governing: SPEC similar-artists-discovery REQ-SIM-020 (chat/completions, model, 2000 tokens, 0.7 temp, json_object),
 // REQ-SIM-021 (auth header via llm.Client), REQ-SIM-022 (API key validation), REQ-SIM-023 (error handling)
-// callOpenAI sends the prompt to OpenAI and returns the response.
-func (s *SimilarArtistsService) callOpenAI(ctx context.Context, prompt string) (string, error) {
+// Governing: SPEC observability REQ-LLM-002 (extract token counts from response usage field)
+// callOpenAI sends the prompt to OpenAI and returns the response content and tokens used.
+func (s *SimilarArtistsService) callOpenAI(ctx context.Context, prompt string) (string, int, error) {
 	if s.config.OpenAI.APIKey == "" {
-		return "", fmt.Errorf("OpenAI API key not configured")
+		return "", 0, fmt.Errorf("OpenAI API key not configured")
 	}
 
 	model := s.config.GetVibesModel()
@@ -285,10 +286,16 @@ func (s *SimilarArtistsService) callOpenAI(ctx context.Context, prompt string) (
 
 	resp, err := s.llm.Chat(ctx, req)
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 
-	return resp.Choices[0].Message.Content, nil
+	// Governing: SPEC observability REQ-LLM-002 — extract token counts when available
+	tokensUsed := 0
+	if resp.Usage != nil {
+		tokensUsed = resp.Usage.TotalTokens
+	}
+
+	return resp.Choices[0].Message.Content, tokensUsed, nil
 }
 
 // Governing: SPEC similar-artists-discovery REQ-SIM-030 (strip markdown fences, find outermost JSON object, unmarshal)


### PR DESCRIPTION
## Summary

- Fixes `callOpenAI()` in `SimilarArtistsService` to return actual token counts extracted from `resp.Usage.TotalTokens` instead of hardcoded `0`
- `metric.llm` events for `operation=similar_artists` now log real `tokens_used` values
- Matches the same pattern already used in `vibes/generator.go` and `vibes/enhancer.go`

## Requirements Verified

- [x] **REQ-LLM-001** (`metric.llm` per API call) — already existed
- [x] **REQ-LLM-002** (token counts extracted from usage field) — **fixed**: was hardcoded `0`, now extracts from `resp.Usage.TotalTokens`
- [x] **REQ-LLM-003** (`operation` field distinguishes use cases) — already existed (`"similar_artists"`)
- [x] **REQ-MATCH-001..003** (track match metrics) — already existed in `track_matcher.go`

Closes #200
Part of #191 (observability)
Governing: SPEC observability REQ-LLM-002 (extract token counts from API response usage field)