### PR TITLE
UI Tag Visual Differentiation with TypedTagBadge

### DIFF
--- a/internal/views/albums/show.templ
+++ b/internal/views/albums/show.templ
@@ -306,6 +306,7 @@ templ Show(album *ent.Album, tracks []TrackWithListens, stats *AlbumStats, djs [
 									{ album.Edges.Artist.Name }
 								</a>
 							}
+							// TODO(SPEC-0014): Replace with TypedTagBadge after Tag schema PR #255 merges
 							<!-- All Tags -->
 							if allTags := collectAndSortAllTags(album, tracks); len(allTags) > 0 {
 								<div class="flex flex-wrap gap-1.5 mb-3">

--- a/internal/views/artists/show.templ
+++ b/internal/views/artists/show.templ
@@ -258,6 +258,7 @@ templ Show(artist *ent.Artist, albums []*ent.Album, playlists []PlaylistWithArti
 						<!-- Artist Details -->
 						<div class="flex-1 min-w-0">
 							<h1 class="text-4xl md:text-5xl font-bold mb-2 text-base-content">{ artist.Name }</h1>
+							// TODO(SPEC-0014): Replace with TypedTagBadge after Tag schema PR #255 merges
 							<!-- Genres and AI Tags -->
 							if len(artist.Genres) > 0 || len(artist.AiTags) > 0 {
 								<div class="flex flex-wrap gap-2 mb-6">
@@ -445,6 +446,7 @@ templ Show(artist *ent.Artist, albums []*ent.Album, playlists []PlaylistWithArti
 					</div>
 				</div>
 			}
+			// TODO(SPEC-0014): Replace with TypedTagGroup after Tag schema PR #255 merges
 			<!-- Track Tags & Genres Section -->
 			if trackTags := collectTrackTags(albums); len(trackTags) > 0 || len(collectTrackGenres(albums)) > 0 || len(collectTrackAITags(albums)) > 0 {
 				<div class="card bg-base-100 shadow-xl mb-8">

--- a/internal/views/components/tags.templ
+++ b/internal/views/components/tags.templ
@@ -1,0 +1,53 @@
+package components
+
+// TagView represents a displayable tag with its type for UI rendering.
+// Governing: SPEC-0014 REQ "UI Tag Visual Differentiation"
+type TagView struct {
+	Name    string
+	TagType string // "id3", "genre", "ai", "label", "source"
+}
+
+// TypedTagBadge renders a single tag with type-specific icon and DaisyUI badge color.
+// Governing: SPEC-0014 REQ "UI Tag Visual Differentiation", ADR-0011 (Tailwind + DaisyUI)
+templ TypedTagBadge(tag TagView) {
+	switch tag.TagType {
+		case "ai":
+			<span class="badge badge-accent gap-1">
+				<span class="icon-[heroicons--sparkles] w-3 h-3"></span>
+				{ tag.Name }
+			</span>
+		case "genre":
+			<span class="badge badge-primary gap-1">
+				<span class="icon-[heroicons--tag] w-3 h-3"></span>
+				{ tag.Name }
+			</span>
+		case "label":
+			<span class="badge badge-secondary gap-1">
+				<span class="icon-[heroicons--building-office] w-3 h-3"></span>
+				{ tag.Name }
+			</span>
+		case "source":
+			<span class="badge badge-info gap-1">
+				<span class="icon-[heroicons--server] w-3 h-3"></span>
+				{ tag.Name }
+			</span>
+		default:
+			<span class="badge badge-neutral gap-1">
+				<span class="icon-[heroicons--musical-note] w-3 h-3"></span>
+				{ tag.Name }
+			</span>
+	}
+}
+
+// TypedTagGroup renders a labeled group of tags of the same type.
+// Governing: SPEC-0014 REQ "UI Tag Visual Differentiation"
+templ TypedTagGroup(label string, tags []TagView) {
+	if len(tags) > 0 {
+		<div class="flex flex-wrap gap-1 items-center">
+			<span class="text-xs text-base-content/50 mr-1">{ label }</span>
+			for _, tag := range tags {
+				@TypedTagBadge(tag)
+			}
+		</div>
+	}
+}

--- a/internal/views/tracks/show.templ
+++ b/internal/views/tracks/show.templ
@@ -293,6 +293,7 @@ templ Show(track *ent.Track, playlists []*ent.Playlist, stats *TrackStats, cfg *
 									@components.ExternalLinkBadge("MusicBrainz", fmt.Sprintf("https://musicbrainz.org/recording/%s", *track.MusicbrainzID), "icon-[heroicons--globe-alt]", "badge-warning")
 								}
 							</div>
+							// TODO(SPEC-0014): Replace with TypedTagBadge after Tag schema PR #255 merges
 							<!-- All Tags (Genres, ID3, AI) -->
 							if len(track.Genres) > 0 || len(track.Tags) > 0 || len(track.AiTags) > 0 {
 								<div class="flex flex-wrap gap-1.5 mb-4">


### PR DESCRIPTION
## Summary

Adds the `TypedTagBadge` and `TypedTagGroup` Templ components for SPEC-0014 typed tag rendering.

**Components added:**
- `TagView` struct: `{ Name, TagType string }` — view model for typed tag display
- `TypedTagBadge(tag TagView)` — renders a single tag with type-specific DaisyUI badge + Heroicon
- `TypedTagGroup(label string, tags []TagView)` — renders a labeled group of same-type tags

**Tag type -> badge mapping:**
| Type | Badge | Icon |
|------|-------|------|
| `id3` | `badge-neutral` | `icon-[heroicons--musical-note]` |
| `genre` | `badge-primary` | `icon-[heroicons--tag]` |
| `ai` | `badge-accent` | `icon-[heroicons--sparkles]` |
| `label` | `badge-secondary` | `icon-[heroicons--building-office]` |
| `source` | `badge-info` | `icon-[heroicons--server]` |

AI tags use `badge-accent` + sparkles, consistent with `AISummaryCard` branding.

**Note:** Page wiring (artist/album/track show pages querying Tag edges) is deferred until the Tag schema PR (#255) merges and ent is regenerated. TODO comments added to each show page marking where `TypedTagBadge` should replace existing inline badge markup.

Closes #253
Part of #250 (epic — Implement Unified Tag Taxonomy)
Governing: SPEC-0014 REQ "UI Tag Visual Differentiation", ADR-0011, ADR-0025