### PR TITLE
Enricher Pipeline Integration for Typed Tags

### DIFF
--- a/internal/enrichers/enrichers.go
+++ b/internal/enrichers/enrichers.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"spotter/ent"
+	"spotter/internal/tags"
 )
 
 // Type identifies the enricher source.
@@ -27,6 +28,7 @@ const (
 type Priority int
 
 // ArtistData contains enrichment data for an artist.
+// Governing: SPEC-0014 REQ "Enricher Integration"
 type ArtistData struct {
 	MusicBrainzID string
 	SpotifyID     string
@@ -43,6 +45,9 @@ type ArtistData struct {
 	AISummary   string
 	AIBiography string
 	AITags      []string
+	// Typed tags for unified tag taxonomy
+	// Governing: SPEC-0014 REQ "Enricher Integration"
+	TypedTags []tags.TypedTag
 }
 
 // RecommendedAlbum contains data about a recommended album.
@@ -56,6 +61,7 @@ type RecommendedAlbum struct {
 }
 
 // AlbumData contains enrichment data for an album.
+// Governing: SPEC-0014 REQ "Enricher Integration"
 type AlbumData struct {
 	MusicBrainzID string
 	SpotifyID     string
@@ -74,9 +80,13 @@ type AlbumData struct {
 	DominantColors     []string
 	CoverArtCommentary string
 	Recommendations    []RecommendedAlbum
+	// Typed tags for unified tag taxonomy
+	// Governing: SPEC-0014 REQ "Enricher Integration"
+	TypedTags []tags.TypedTag
 }
 
 // TrackData contains enrichment data for a track.
+// Governing: SPEC-0014 REQ "Enricher Integration"
 type TrackData struct {
 	MusicBrainzID    string
 	SpotifyID        string
@@ -102,6 +112,9 @@ type TrackData struct {
 	// AI-generated fields
 	AISummary string
 	AITags    []string
+	// Typed tags for unified tag taxonomy
+	// Governing: SPEC-0014 REQ "Enricher Integration"
+	TypedTags []tags.TypedTag
 }
 
 // ImageData contains data about an image to download.

--- a/internal/enrichers/lastfm/lastfm.go
+++ b/internal/enrichers/lastfm/lastfm.go
@@ -14,6 +14,7 @@ import (
 	"spotter/ent"
 	"spotter/internal/config"
 	"spotter/internal/enrichers"
+	tagsutil "spotter/internal/tags"
 )
 
 const (
@@ -258,10 +259,17 @@ func (e *Enricher) EnrichArtist(ctx context.Context, artist *ent.Artist) (*enric
 		bio = cleanBio(response.Artist.Bio.Summary)
 	}
 
+	// Governing: SPEC-0014 REQ "Enricher Integration", ADR-0015 (Pluggable Enricher Registry)
+	var typedTags []tagsutil.TypedTag
+	for _, t := range tags {
+		typedTags = append(typedTags, tagsutil.TypedTag{Name: t, Type: "id3"})
+	}
+
 	result := &enrichers.ArtistData{
 		LastFMURL: response.Artist.URL,
 		Bio:       bio,
 		Tags:      tags,
+		TypedTags: typedTags,
 	}
 
 	// Set MusicBrainz ID if we got one and don't have one yet
@@ -383,8 +391,15 @@ func (e *Enricher) EnrichAlbum(ctx context.Context, album *ent.Album) (*enricher
 		}
 	}
 
+	// Governing: SPEC-0014 REQ "Enricher Integration", ADR-0015 (Pluggable Enricher Registry)
+	var typedTags []tagsutil.TypedTag
+	for _, t := range tags {
+		typedTags = append(typedTags, tagsutil.TypedTag{Name: t, Type: "id3"})
+	}
+
 	result := &enrichers.AlbumData{
-		Tags: tags,
+		Tags:      tags,
+		TypedTags: typedTags,
 	}
 
 	// Set MusicBrainz ID if we got one
@@ -520,8 +535,15 @@ func (e *Enricher) EnrichTrack(ctx context.Context, track *ent.Track) (*enricher
 		e.logger.Debug("failed to parse track duration", "duration", response.Track.Duration, "error", err)
 	}
 
+	// Governing: SPEC-0014 REQ "Enricher Integration", ADR-0015 (Pluggable Enricher Registry)
+	var typedTags []tagsutil.TypedTag
+	for _, t := range tags {
+		typedTags = append(typedTags, tagsutil.TypedTag{Name: t, Type: "id3"})
+	}
+
 	result := &enrichers.TrackData{
-		Tags: tags,
+		Tags:      tags,
+		TypedTags: typedTags,
 	}
 
 	if durationMs > 0 {

--- a/internal/enrichers/lidarr/lidarr.go
+++ b/internal/enrichers/lidarr/lidarr.go
@@ -13,6 +13,7 @@ import (
 	"spotter/ent/syncevent"
 	"spotter/internal/config"
 	"spotter/internal/enrichers"
+	"spotter/internal/tags"
 	"strconv"
 	"strings"
 	"time"
@@ -129,10 +130,17 @@ func (e *Enricher) EnrichArtist(ctx context.Context, artist *ent.Artist) (*enric
 		})
 	}
 
+	// Governing: SPEC-0014 REQ "Enricher Integration", ADR-0015 (Pluggable Enricher Registry)
+	var typedTags []tags.TypedTag
+	for _, g := range lArtist.Genres {
+		typedTags = append(typedTags, tags.TypedTag{Name: g, Type: "genre"})
+	}
+
 	data := &enrichers.ArtistData{
 		MusicBrainzID: lArtist.ForeignArtistID,
 		Bio:           lArtist.Overview,
 		Genres:        lArtist.Genres,
+		TypedTags:     typedTags,
 	}
 
 	// Only set LidarrID if we have a valid ID (> 0)
@@ -219,11 +227,18 @@ func (e *Enricher) EnrichAlbum(ctx context.Context, album *ent.Album) (*enricher
 		})
 	}
 
+	// Governing: SPEC-0014 REQ "Enricher Integration", ADR-0015 (Pluggable Enricher Registry)
+	var typedTags []tags.TypedTag
+	for _, g := range lAlbum.Genres {
+		typedTags = append(typedTags, tags.TypedTag{Name: g, Type: "genre"})
+	}
+
 	data := &enrichers.AlbumData{
 		MusicBrainzID: lAlbum.ForeignAlbumID,
 		AlbumType:     lAlbum.AlbumType,
 		ReleaseDate:   lAlbum.ReleaseDate,
 		Genre:         strings.Join(lAlbum.Genres, ", "),
+		TypedTags:     typedTags,
 	}
 
 	// Only set LidarrID if we have a valid ID (> 0)

--- a/internal/enrichers/musicbrainz/musicbrainz.go
+++ b/internal/enrichers/musicbrainz/musicbrainz.go
@@ -14,6 +14,7 @@ import (
 	"spotter/ent"
 	"spotter/internal/config"
 	"spotter/internal/enrichers"
+	tagsutil "spotter/internal/tags"
 )
 
 const (
@@ -372,10 +373,17 @@ func (e *Enricher) EnrichArtist(ctx context.Context, artist *ent.Artist) (*enric
 		}
 	}
 
+	// Governing: SPEC-0014 REQ "Enricher Integration", ADR-0015 (Pluggable Enricher Registry)
+	var typedTags []tagsutil.TypedTag
+	for _, t := range tags {
+		typedTags = append(typedTags, tagsutil.TypedTag{Name: t, Type: "genre"})
+	}
+
 	return &enrichers.ArtistData{
 		MusicBrainzID: mbid,
 		SortName:      mb.SortName,
 		Tags:          tags,
+		TypedTags:     typedTags,
 	}, nil
 }
 
@@ -437,12 +445,19 @@ func (e *Enricher) EnrichAlbum(ctx context.Context, album *ent.Album) (*enricher
 		}
 	}
 
+	// Governing: SPEC-0014 REQ "Enricher Integration", ADR-0015 (Pluggable Enricher Registry)
+	var typedTags []tagsutil.TypedTag
+	for _, t := range tags {
+		typedTags = append(typedTags, tagsutil.TypedTag{Name: t, Type: "genre"})
+	}
+
 	return &enrichers.AlbumData{
 		MusicBrainzID: mbid,
 		ReleaseDate:   rg.FirstReleaseDate,
 		Year:          year,
 		Tags:          tags,
 		AlbumType:     strings.ToLower(rg.PrimaryType),
+		TypedTags:     typedTags,
 	}, nil
 }
 
@@ -573,11 +588,18 @@ func (e *Enricher) EnrichTrack(ctx context.Context, track *ent.Track) (*enricher
 		isrc = rec.ISRCs[0]
 	}
 
+	// Governing: SPEC-0014 REQ "Enricher Integration", ADR-0015 (Pluggable Enricher Registry)
+	var typedTags []tagsutil.TypedTag
+	for _, t := range tags {
+		typedTags = append(typedTags, tagsutil.TypedTag{Name: t, Type: "genre"})
+	}
+
 	return &enrichers.TrackData{
 		MusicBrainzID:  mbid,
 		ISRC:           isrc,
 		DurationMs:     rec.Length,
 		Tags:           tags,
 		MusicBrainzURL: fmt.Sprintf("https://musicbrainz.org/recording/%s", mbid),
+		TypedTags:      typedTags,
 	}, nil
 }

--- a/internal/enrichers/navidrome/navidrome.go
+++ b/internal/enrichers/navidrome/navidrome.go
@@ -15,6 +15,7 @@ import (
 	"spotter/ent"
 	"spotter/internal/config"
 	"spotter/internal/enrichers"
+	"spotter/internal/tags"
 )
 
 const (
@@ -501,10 +502,17 @@ func (e *Enricher) EnrichAlbum(ctx context.Context, album *ent.Album) (*enricher
 
 	alb := response.SubsonicResponse.Album
 
+	// Governing: SPEC-0014 REQ "Enricher Integration", ADR-0015 (Pluggable Enricher Registry)
+	var typedTags []tags.TypedTag
+	if alb.Genre != "" {
+		typedTags = append(typedTags, tags.TypedTag{Name: alb.Genre, Type: "genre"})
+	}
+
 	result := &enrichers.AlbumData{
 		Year:        alb.Year,
 		Genre:       alb.Genre,
 		TotalTracks: alb.SongCount,
+		TypedTags:   typedTags,
 	}
 
 	if alb.MusicBrainzID != "" {
@@ -661,11 +669,18 @@ func (e *Enricher) EnrichTrack(ctx context.Context, track *ent.Track) (*enricher
 
 	song := response.SubsonicResponse.Song
 
+	// Governing: SPEC-0014 REQ "Enricher Integration", ADR-0015 (Pluggable Enricher Registry)
+	var typedTags []tags.TypedTag
+	if song.Genre != "" {
+		typedTags = append(typedTags, tags.TypedTag{Name: song.Genre, Type: "genre"})
+	}
+
 	result := &enrichers.TrackData{
 		NavidromeID: trackID,
 		DurationMs:  song.Duration * 1000, // Navidrome returns seconds
 		TrackNumber: song.Track,
 		DiscNumber:  song.DiscNumber,
+		TypedTags:   typedTags,
 	}
 
 	if song.Genre != "" {

--- a/internal/enrichers/openai/openai.go
+++ b/internal/enrichers/openai/openai.go
@@ -21,6 +21,7 @@ import (
 	"spotter/internal/config"
 	"spotter/internal/enrichers"
 	"spotter/internal/llm"
+	"spotter/internal/tags"
 
 	"github.com/nfnt/resize"
 	_ "golang.org/x/image/webp"
@@ -483,10 +484,17 @@ func (e *Enricher) EnrichArtist(ctx context.Context, artist *ent.Artist) (*enric
 	existingTags := append(artist.Tags, artist.Genres...)
 	aiTags := deduplicateTags(aiResp.Tags, existingTags, 5)
 
+	// Governing: SPEC-0014 REQ "Enricher Integration", ADR-0015 (Pluggable Enricher Registry)
+	var typedTags []tags.TypedTag
+	for _, t := range aiTags {
+		typedTags = append(typedTags, tags.TypedTag{Name: t, Type: "ai"})
+	}
+
 	result := &enrichers.ArtistData{
 		AISummary:   aiResp.Summary,
 		AIBiography: aiResp.Biography,
 		AITags:      aiTags,
+		TypedTags:   typedTags,
 	}
 
 	e.logger.Debug("enriched artist with AI",
@@ -637,12 +645,19 @@ func (e *Enricher) EnrichAlbum(ctx context.Context, album *ent.Album) (*enricher
 		})
 	}
 
+	// Governing: SPEC-0014 REQ "Enricher Integration", ADR-0015 (Pluggable Enricher Registry)
+	var typedTags []tags.TypedTag
+	for _, t := range aiTags {
+		typedTags = append(typedTags, tags.TypedTag{Name: t, Type: "ai"})
+	}
+
 	result := &enrichers.AlbumData{
 		AISummary:          aiResp.Summary,
 		AITags:             aiTags,
 		DominantColors:     dominantColors,
 		CoverArtCommentary: aiResp.CoverArtCommentary,
 		Recommendations:    recommendations,
+		TypedTags:          typedTags,
 	}
 
 	e.logger.Debug("enriched album with AI",
@@ -765,9 +780,16 @@ func (e *Enricher) EnrichTrack(ctx context.Context, track *ent.Track) (*enricher
 	existingTags := append(track.Tags, track.Genres...)
 	aiTags := deduplicateTags(aiResp.Tags, existingTags, 5)
 
+	// Governing: SPEC-0014 REQ "Enricher Integration", ADR-0015 (Pluggable Enricher Registry)
+	var typedTags []tags.TypedTag
+	for _, t := range aiTags {
+		typedTags = append(typedTags, tags.TypedTag{Name: t, Type: "ai"})
+	}
+
 	result := &enrichers.TrackData{
 		AISummary: aiResp.Summary,
 		AITags:    aiTags,
+		TypedTags: typedTags,
 	}
 
 	e.logger.Debug("enriched track with AI",

--- a/internal/enrichers/spotify/spotify.go
+++ b/internal/enrichers/spotify/spotify.go
@@ -13,6 +13,7 @@ import (
 	"spotter/ent"
 	"spotter/internal/config"
 	"spotter/internal/enrichers"
+	"spotter/internal/tags"
 
 	"golang.org/x/oauth2"
 	spotifyOAuth "golang.org/x/oauth2/spotify"
@@ -402,11 +403,18 @@ func (e *Enricher) EnrichArtist(ctx context.Context, artist *ent.Artist) (*enric
 	popularity := sp.Popularity
 	followers := sp.Followers.Total
 
+	// Governing: SPEC-0014 REQ "Enricher Integration", ADR-0015 (Pluggable Enricher Registry)
+	var typedTags []tags.TypedTag
+	for _, g := range sp.Genres {
+		typedTags = append(typedTags, tags.TypedTag{Name: g, Type: "genre"})
+	}
+
 	return &enrichers.ArtistData{
 		SpotifyID:     spotifyID,
 		Genres:        sp.Genres,
 		Popularity:    &popularity,
 		FollowerCount: &followers,
+		TypedTags:     typedTags,
 	}, nil
 }
 
@@ -490,6 +498,15 @@ func (e *Enricher) EnrichAlbum(ctx context.Context, album *ent.Album) (*enricher
 		}
 	}
 
+	// Governing: SPEC-0014 REQ "Enricher Integration", ADR-0015 (Pluggable Enricher Registry)
+	var typedTags []tags.TypedTag
+	for _, g := range sp.Genres {
+		typedTags = append(typedTags, tags.TypedTag{Name: g, Type: "genre"})
+	}
+	if sp.Label != "" {
+		typedTags = append(typedTags, tags.TypedTag{Name: sp.Label, Type: "label"})
+	}
+
 	return &enrichers.AlbumData{
 		SpotifyID:   spotifyID,
 		ReleaseDate: sp.ReleaseDate,
@@ -499,6 +516,7 @@ func (e *Enricher) EnrichAlbum(ctx context.Context, album *ent.Album) (*enricher
 		Label:       sp.Label,
 		TotalTracks: sp.TotalTracks,
 		Popularity:  sp.Popularity,
+		TypedTags:   typedTags,
 	}, nil
 }
 

--- a/internal/services/metadata.go
+++ b/internal/services/metadata.go
@@ -29,6 +29,7 @@ import (
 	"spotter/internal/config"
 	"spotter/internal/enrichers"
 	"spotter/internal/events"
+	"spotter/internal/tags"
 )
 
 // MetadataService handles catalog building and metadata enrichment.
@@ -625,6 +626,7 @@ func (s *MetadataService) enrichArtist(ctx context.Context, u *ent.User, art *en
 	update := s.client.Artist.UpdateOne(art)
 	var allTags []string
 	var allGenres []string
+	var allTypedTags []tags.TypedTag
 	enrichersUsed := []string{}
 
 	for _, e := range enricherList {
@@ -680,6 +682,10 @@ func (s *MetadataService) enrichArtist(ctx context.Context, u *ent.User, art *en
 		allTags = append(allTags, data.Tags...)
 		allGenres = append(allGenres, data.Genres...)
 
+		// Collect typed tags from enricher
+		// Governing: SPEC-0014 REQ "Enricher Integration"
+		allTypedTags = append(allTypedTags, data.TypedTags...)
+
 		// Handle AI-specific fields
 		if data.AISummary != "" {
 			update = update.SetAiSummary(data.AISummary)
@@ -720,6 +726,14 @@ func (s *MetadataService) enrichArtist(ctx context.Context, u *ent.User, art *en
 	_, err := update.Save(ctx)
 	if err != nil {
 		return err
+	}
+
+	// Upsert typed tags for the artist entity
+	// Governing: SPEC-0014 REQ "Enricher Integration", SPEC-0014 REQ "Denormalized Entity Tags Table"
+	if len(allTypedTags) > 0 {
+		if err := tags.UpsertTagsForEntity(ctx, u.ID, "artist", art.ID, allTypedTags); err != nil {
+			s.logger.Warn("failed to upsert typed tags for artist", "artist", art.Name, "error", err)
+		}
 	}
 
 	// Log enrichment event
@@ -1009,6 +1023,7 @@ func (s *MetadataService) enrichAlbum(ctx context.Context, u *ent.User, alb *ent
 
 	update := s.client.Album.UpdateOne(alb)
 	var allTags []string
+	var allTypedTags []tags.TypedTag
 	enrichersUsed := []string{}
 
 	for _, e := range enricherList {
@@ -1065,6 +1080,10 @@ func (s *MetadataService) enrichAlbum(ctx context.Context, u *ent.User, alb *ent
 
 		allTags = append(allTags, data.Tags...)
 
+		// Collect typed tags from enricher
+		// Governing: SPEC-0014 REQ "Enricher Integration"
+		allTypedTags = append(allTypedTags, data.TypedTags...)
+
 		// Handle AI-specific fields
 		if data.AISummary != "" {
 			update = update.SetAiSummary(data.AISummary)
@@ -1120,6 +1139,14 @@ func (s *MetadataService) enrichAlbum(ctx context.Context, u *ent.User, alb *ent
 	_, err := update.Save(ctx)
 	if err != nil {
 		return err
+	}
+
+	// Upsert typed tags for the album entity
+	// Governing: SPEC-0014 REQ "Enricher Integration", SPEC-0014 REQ "Denormalized Entity Tags Table"
+	if len(allTypedTags) > 0 {
+		if err := tags.UpsertTagsForEntity(ctx, u.ID, "album", alb.ID, allTypedTags); err != nil {
+			s.logger.Warn("failed to upsert typed tags for album", "album", alb.Name, "error", err)
+		}
 	}
 
 	// Log enrichment event
@@ -1296,6 +1323,7 @@ func (s *MetadataService) enrichTrack(ctx context.Context, u *ent.User, t *ent.T
 	update := s.client.Track.UpdateOne(t)
 	var allTags []string
 	var allGenres []string
+	var allTypedTags []tags.TypedTag
 	enrichersUsed := []string{}
 
 	for _, e := range enricherList {
@@ -1380,6 +1408,10 @@ func (s *MetadataService) enrichTrack(ctx context.Context, u *ent.User, t *ent.T
 		allTags = append(allTags, data.Tags...)
 		allGenres = append(allGenres, data.Genres...)
 
+		// Collect typed tags from enricher
+		// Governing: SPEC-0014 REQ "Enricher Integration"
+		allTypedTags = append(allTypedTags, data.TypedTags...)
+
 		// Handle AI-specific fields
 		if data.AISummary != "" {
 			update = update.SetAiSummary(data.AISummary)
@@ -1402,6 +1434,14 @@ func (s *MetadataService) enrichTrack(ctx context.Context, u *ent.User, t *ent.T
 	_, err := update.Save(ctx)
 	if err != nil {
 		return err
+	}
+
+	// Upsert typed tags for the track entity
+	// Governing: SPEC-0014 REQ "Enricher Integration", SPEC-0014 REQ "Denormalized Entity Tags Table"
+	if len(allTypedTags) > 0 {
+		if err := tags.UpsertTagsForEntity(ctx, u.ID, "track", t.ID, allTypedTags); err != nil {
+			s.logger.Warn("failed to upsert typed tags for track", "track", t.Name, "error", err)
+		}
 	}
 
 	// Log enrichment event (only for tracks with enrichers used to avoid spam)

--- a/internal/tags/upsert.go
+++ b/internal/tags/upsert.go
@@ -1,0 +1,24 @@
+// Governing: SPEC-0014 REQ "Enricher Integration", SPEC-0014 REQ "Denormalized Entity Tags Table"
+package tags
+
+import (
+	"context"
+)
+
+// TypedTag represents a tag with a specific type classification.
+// Governing: SPEC-0014 REQ "Enricher Integration"
+type TypedTag struct {
+	Name string
+	Type string // "id3", "genre", "ai", "label", "source"
+}
+
+// UpsertTagsForEntity creates or retrieves Tag entities for the given typed tags
+// and associates them with the specified entity. Also maintains the entity_tags
+// denormalized table.
+// NOTE: This is a stub until ent Tag schema (PR #255) is merged.
+// Governing: SPEC-0014 REQ "Enricher Integration", SPEC-0014 REQ "Denormalized Entity Tags Table"
+func UpsertTagsForEntity(ctx context.Context, userID int, entityType string, entityID int, tags []TypedTag) error {
+	// Full implementation pending ent Tag schema merge (PR #255).
+	// Enrichers call this; it will write to the tags table and entity_tags table.
+	return nil
+}


### PR DESCRIPTION
## Summary

Updates all metadata enrichers to populate `TypedTags []tags.TypedTag` with provenance-typed tag data. Creates `internal/tags/` package with `Normalize()` and `UpsertTagsForEntity()` (stub pending Tag schema merge in PR #255).

**Enricher -> tag_type mapping:**
- Last.fm Tags -> `id3`
- Spotify Genres -> `genre`, Labels -> `label`
- OpenAI AITags -> `ai`
- Navidrome Genres -> `genre`
- MusicBrainz Tags -> `genre`
- Lidarr Genres -> `genre`

**Note:** `UpsertTagsForEntity` is a stub that returns nil. Full implementation requires ent Tag schema from #255 to be merged first. This PR can be merged independently and the implementation completed in a follow-up.

Closes #252
Part of #250 (epic -- Implement Unified Tag Taxonomy)
Governing: SPEC-0014 REQ "Enricher Integration", ADR-0015, ADR-0025