### PR TITLE
Add loading spinner to provider sync button

### DIFF
--- a/internal/views/components/action_button_dropdown.templ
+++ b/internal/views/components/action_button_dropdown.templ
@@ -343,18 +343,19 @@ templ dropdownActionItem(action DropdownAction) {
 			} else {
 				hx-swap="none"
 			}
-			class={ "flex items-center gap-2", action.IconColor }
+			class={ "flex items-center gap-2 relative", action.IconColor }
 			onclick="this.closest('details').removeAttribute('open')"
 		>
 			if action.IconClass != "" {
-				<span class={ action.IconClass, "w-4 h-4" }></span>
+				<span class={ action.IconClass, "w-4 h-4 htmx-indicator-hide" }></span>
 			}
-			<div class="flex flex-col items-start">
+			<div class="flex flex-col items-start htmx-indicator-hide">
 				<span>{ action.Label }</span>
 				if action.Description != "" {
 					<span class="text-xs text-base-content/60">{ action.Description }</span>
 				}
 			</div>
+			<span class="loading loading-spinner loading-xs htmx-indicator absolute"></span>
 		</button>
 	} else if action.HtmxGet != "" {
 		// HTMX GET action
@@ -366,18 +367,19 @@ templ dropdownActionItem(action DropdownAction) {
 			} else {
 				hx-swap="none"
 			}
-			class={ "flex items-center gap-2", action.IconColor }
+			class={ "flex items-center gap-2 relative", action.IconColor }
 			onclick="this.closest('details').removeAttribute('open')"
 		>
 			if action.IconClass != "" {
-				<span class={ action.IconClass, "w-4 h-4" }></span>
+				<span class={ action.IconClass, "w-4 h-4 htmx-indicator-hide" }></span>
 			}
-			<div class="flex flex-col items-start">
+			<div class="flex flex-col items-start htmx-indicator-hide">
 				<span>{ action.Label }</span>
 				if action.Description != "" {
 					<span class="text-xs text-base-content/60">{ action.Description }</span>
 				}
 			</div>
+			<span class="loading loading-spinner loading-xs htmx-indicator absolute"></span>
 		</button>
 	}
 }


### PR DESCRIPTION
## Summary
- Add HTMX loading indicator (spinner) to dropdown action buttons that use `hx-swap="none"` (sync buttons in provider menus)
- Apply `htmx-indicator-hide` to icon and label elements so they fade out during the request
- Add `htmx-indicator` spinner that appears while the HTMX request is in-flight
- Pattern matches the existing loading indicator used in preferences task buttons (`events.templ`)

## Test plan
- [ ] Click "Sync Now" in a provider dropdown menu and verify a spinner appears while the request is in-flight
- [ ] Verify the icon and label text hide while the spinner is showing
- [ ] Verify the spinner disappears after the request completes
- [ ] Verify dropdown actions with `hx-target` (non-none swap) also show the spinner correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)