### PR TITLE
Preferences UI: email address input, SMTP status badge, and test notification

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -458,6 +458,9 @@ func main() {
 		r.Post("/generate", h.GeneratePlaylist)
 
 		r.Get("/preferences", h.PreferencesRedirect)
+		r.Get("/preferences/account", h.PreferencesAccount)
+		r.Post("/preferences/account/email", h.PostPreferencesEmail)
+		r.Post("/preferences/notifications/test", h.PostTestNotification)
 		r.Get("/preferences/appearance", h.PreferencesAppearance)
 		r.Post("/preferences/appearance", h.PostPreferencesAppearance)
 		r.Get("/preferences/providers", h.PreferencesProviders)

--- a/internal/handlers/preferences.go
+++ b/internal/handlers/preferences.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/mail"
 	"strconv"
 	"time"
 
@@ -82,6 +83,69 @@ func (h *Handler) PostPreferencesAppearance(w http.ResponseWriter, r *http.Reque
 
 	w.Header().Set("HX-Trigger", "preferences-saved")
 	w.WriteHeader(http.StatusOK)
+}
+
+// Governing: SPEC-0015 REQ "User Email Address", REQ "Preferences UI — Email Address and Notification Status"
+func (h *Handler) PreferencesAccount(w http.ResponseWriter, r *http.Request) {
+	u := h.GetUser(r.Context())
+	if u == nil {
+		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
+		return
+	}
+
+	smtpConfigured := h.Config.SMTP.Host != ""
+	h.Render(w, r, preferences.Account(u, h.Config, smtpConfigured))
+}
+
+// Governing: SPEC-0015 REQ "User Email Address"
+func (h *Handler) PostPreferencesEmail(w http.ResponseWriter, r *http.Request) {
+	u := h.GetUser(r.Context())
+	if u == nil {
+		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
+		return
+	}
+
+	email := r.FormValue("email")
+
+	if email != "" {
+		if _, err := mail.ParseAddress(email); err != nil {
+			h.Render(w, r, components.Toast("Invalid email", "Please enter a valid email address", "error"))
+			return
+		}
+	}
+
+	err := h.Client.User.UpdateOneID(u.ID).
+		SetEmail(email).
+		Exec(r.Context())
+	if err != nil {
+		h.Logger.Error("failed to update user email", "error", err)
+		h.Render(w, r, components.Toast("Error", "Failed to save email address", "error"))
+		return
+	}
+
+	h.Render(w, r, components.Toast("Saved", "Email address updated", "success"))
+}
+
+// Governing: SPEC-0015 REQ "Preferences UI — Email Address and Notification Status"
+func (h *Handler) PostTestNotification(w http.ResponseWriter, r *http.Request) {
+	u := h.GetUser(r.Context())
+	if u == nil {
+		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
+		return
+	}
+
+	if h.Notifier == nil {
+		h.Render(w, r, components.Toast("Error", "Notification service is not available", "error"))
+		return
+	}
+
+	if err := h.Notifier.SendTest(r.Context(), u); err != nil {
+		h.Logger.Error("failed to send test notification", "error", err)
+		h.Render(w, r, components.Toast("Error", "Failed to send test email: "+err.Error(), "error"))
+		return
+	}
+
+	h.Render(w, r, components.Toast("Sent", "Test notification sent to "+u.Email, "success"))
 }
 
 func (h *Handler) PreferencesProviders(w http.ResponseWriter, r *http.Request) {

--- a/internal/notifications/notifier.go
+++ b/internal/notifications/notifier.go
@@ -3,6 +3,7 @@ package notifications
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -32,6 +33,11 @@ func (n *NoopNotifier) NotifyIfNeeded(_ context.Context, _ *ent.User, _ string, 
 
 func (n *NoopNotifier) ClearCooldown(_ context.Context, _ int, _ string) error {
 	return nil
+}
+
+// Governing: SPEC-0015 REQ "Preferences UI — Email Address and Notification Status"
+func (n *NoopNotifier) SendTest(_ context.Context, _ *ent.User) error {
+	return fmt.Errorf("SMTP is not configured")
 }
 
 // DBNotifier persists notification state in the database and sends email via SMTP.
@@ -140,6 +146,22 @@ func (n *DBNotifier) NotifyIfNeeded(ctx context.Context, u *ent.User, provider s
 	n.logger.Info("sent sync failure notification",
 		"user_id", u.ID, "provider", provider, "email", u.Email)
 	return nil
+}
+
+// SendTest sends a test notification email to the user to verify SMTP configuration.
+// Governing: SPEC-0015 REQ "Preferences UI — Email Address and Notification Status"
+func (n *DBNotifier) SendTest(_ context.Context, u *ent.User) error {
+	if u.Email == "" {
+		return fmt.Errorf("no email address configured")
+	}
+	if !n.mailer.IsConfigured() {
+		return fmt.Errorf("SMTP is not configured")
+	}
+
+	subject := "[Spotter] Test notification"
+	body := fmt.Sprintf("Hi,\n\nThis is a test notification from Spotter.\n\nYour email notifications are working correctly.\n\nInstance: %s\n\n— Spotter\n", n.baseURL)
+
+	return n.mailer.Send(u.Email, subject, body)
 }
 
 // ClearCooldown deletes the sync_notification record for a user+provider pair,

--- a/internal/services/sync.go
+++ b/internal/services/sync.go
@@ -24,6 +24,8 @@ import (
 type SyncNotifier interface {
 	NotifyIfNeeded(ctx context.Context, u *ent.User, provider string, syncErr error) error
 	ClearCooldown(ctx context.Context, userID int, provider string) error
+	// Governing: SPEC-0015 REQ "Preferences UI — Email Address and Notification Status"
+	SendTest(ctx context.Context, u *ent.User) error
 }
 
 // Governing: ADR-0020 (exponential backoff and circuit breaker), ADR-0007 (event bus for notifications), SPEC error-handling

--- a/internal/views/layouts/dashboard.templ
+++ b/internal/views/layouts/dashboard.templ
@@ -19,7 +19,8 @@ func isPreferencesActive(currentPath string) bool {
 	return isPreferencesSection(currentPath) &&
 		!isActive(currentPath, "/preferences/appearance") &&
 		!isActive(currentPath, "/preferences/providers") &&
-		!isActive(currentPath, "/preferences/tasks")
+		!isActive(currentPath, "/preferences/tasks") &&
+		!isActive(currentPath, "/preferences/account")
 }
 
 func isLibrarySection(currentPath string) bool {
@@ -147,6 +148,12 @@ templ Dashboard(title string, cfg *config.Config, currentPath string) {
 										<span>Preferences</span>
 									</summary>
 									<ul>
+										<li>
+											<a href="/preferences/account" class={ "flex items-center gap-3", templ.KV("active", isActive(currentPath, "/preferences/account")) }>
+												<span class="icon-[heroicons--user-circle] w-5 h-5"></span>
+												<span>Account</span>
+											</a>
+										</li>
 										<li>
 											<a href="/preferences/appearance" class={ "flex items-center gap-3", templ.KV("active", isActive(currentPath, "/preferences/appearance")) }>
 												<span class="icon-[heroicons--paint-brush] w-5 h-5"></span>

--- a/internal/views/preferences/account.templ
+++ b/internal/views/preferences/account.templ
@@ -1,0 +1,109 @@
+// Governing: SPEC-0015 REQ "User Email Address", REQ "Preferences UI — Email Address and Notification Status"
+package preferences
+
+import (
+	"spotter/ent"
+	"spotter/internal/config"
+	"spotter/internal/views/layouts"
+)
+
+templ Account(user *ent.User, cfg *config.Config, smtpConfigured bool) {
+	@layouts.Dashboard("Account | Spotter", cfg, "/preferences/account") {
+		<div class="max-w-5xl mx-auto">
+			<div class="mb-8">
+				<h2 class="text-3xl font-bold">Account</h2>
+				<p class="text-base-content/60 mt-2">Manage your email and notification settings</p>
+			</div>
+			<div class="space-y-6">
+				<!-- Email Settings Card -->
+				// Governing: SPEC-0015 REQ "User Email Address"
+				<div class="card bg-base-100 shadow-xl">
+					<div class="card-body">
+						<h3 class="card-title">
+							<span class="icon-[heroicons--envelope] w-6 h-6"></span>
+							Email Address
+						</h3>
+						<p class="text-base-content/60 text-sm mt-1">
+							Used for sync failure notifications. Leave blank to disable email notifications.
+						</p>
+						<form
+							hx-post="/preferences/account/email"
+							hx-target="#toasts"
+							hx-swap="beforeend"
+							class="space-y-4 mt-4"
+						>
+							<div class="form-control">
+								<label class="label">
+									<span class="label-text font-medium">Email</span>
+								</label>
+								<input
+									type="email"
+									name="email"
+									value={ user.Email }
+									maxlength="320"
+									placeholder="you@example.com"
+									class="input input-bordered w-full max-w-md"
+								/>
+							</div>
+							<div class="card-actions">
+								<button type="submit" class="btn btn-primary gap-2">
+									<span class="icon-[heroicons--check] w-5 h-5"></span>
+									Save Email
+								</button>
+							</div>
+						</form>
+					</div>
+				</div>
+				<!-- Notification Status Card -->
+				// Governing: SPEC-0015 REQ "Preferences UI — Email Address and Notification Status"
+				<div class="card bg-base-100 shadow-xl">
+					<div class="card-body">
+						<h3 class="card-title">
+							<span class="icon-[heroicons--bell] w-6 h-6"></span>
+							Notifications
+						</h3>
+						<div class="mt-4 space-y-4">
+							<!-- SMTP Status -->
+							<div class="flex items-center gap-3">
+								<span class="font-medium text-sm">SMTP Status:</span>
+								if smtpConfigured {
+									<span class="badge badge-success gap-1">
+										<span class="icon-[heroicons--check-circle] w-4 h-4"></span>
+										Configured
+									</span>
+								} else {
+									<span class="badge badge-warning gap-1">
+										<span class="icon-[heroicons--exclamation-triangle] w-4 h-4"></span>
+										Not configured
+									</span>
+								}
+							</div>
+							if !smtpConfigured {
+								<div class="alert alert-warning">
+									<span class="icon-[heroicons--exclamation-triangle] w-5 h-5"></span>
+									<span>Email notifications are disabled — SMTP is not configured on this instance.</span>
+								</div>
+							}
+							<!-- Test Notification Button -->
+							if smtpConfigured && user.Email != "" {
+								<div class="divider"></div>
+								<div class="flex items-center gap-4">
+									<button
+										class="btn btn-outline btn-sm gap-2"
+										hx-post="/preferences/notifications/test"
+										hx-target="#toasts"
+										hx-swap="beforeend"
+									>
+										<span class="icon-[heroicons--paper-airplane] w-4 h-4"></span>
+										Send Test Notification
+									</button>
+									<span class="text-base-content/60 text-sm">Send a test email to verify your configuration</span>
+								</div>
+							}
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	}
+}


### PR DESCRIPTION
Closes #264
Part of #261 (SPEC-0015)
Depends on #263

Governing: SPEC-0015 REQ "User Email Address", REQ "Preferences UI — Email Address and Notification Status", ADR-0026

## Changes
- New Account preferences page (`/preferences/account`) with email input field
- `POST /preferences/account/email` handler — validates email with `net/mail.ParseAddress`, upserts `User.email`
- SMTP status badge on Account page — shows "Configured" (green) or "Not configured" (warning) based on `cfg.SMTP.Host`
- Warning alert when SMTP is not configured: "Email notifications are disabled — SMTP is not configured on this instance"
- "Send Test Notification" button — visible only when user has email set AND SMTP is configured
- `POST /preferences/notifications/test` handler — calls `Notifier.SendTest()` to verify SMTP delivery
- `SendTest` method added to `SyncNotifier` interface, implemented on `DBNotifier` (sends test email) and `NoopNotifier` (returns error)
- Account nav item added to sidebar preferences section
- Routes registered in `cmd/server/main.go`

## Test Plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` all tests pass
- [ ] Navigate to `/preferences/account` — email input shows current value
- [ ] Save email — toast confirms success
- [ ] Save invalid email — toast shows validation error
- [ ] SMTP status badge reflects server configuration
- [ ] Test notification button sends email when SMTP + email configured