### PR TITLE
Add error-path tests: sync, metadata, vibes seed

### DIFF
--- a/internal/services/metadata_service_test.go
+++ b/internal/services/metadata_service_test.go
@@ -1,0 +1,53 @@
+package services_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"spotter/ent"
+	"spotter/internal/config"
+	"spotter/internal/enrichers"
+	"spotter/internal/events"
+	"spotter/internal/services"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetadataService_GetEnricherFactory_Registered(t *testing.T) {
+	client := setupSimilarArtistsTestDB(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	bus := events.NewBus()
+	svc := services.NewMetadataService(client, nil, &config.Config{}, logger, bus)
+
+	// Register a factory
+	called := false
+	factory := func(ctx context.Context, user *ent.User) (enrichers.Enricher, error) {
+		called = true
+		return nil, nil
+	}
+	svc.Register(enrichers.TypeSpotify, factory)
+
+	// Get the factory back
+	got, ok := svc.GetEnricherFactory(enrichers.TypeSpotify)
+	require.True(t, ok, "registered factory should be found")
+	require.NotNil(t, got)
+
+	// Verify it's the same factory by calling it
+	_, _ = got(context.Background(), nil)
+	assert.True(t, called, "returned factory should be the one we registered")
+}
+
+func TestMetadataService_GetEnricherFactory_Unregistered(t *testing.T) {
+	client := setupSimilarArtistsTestDB(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	bus := events.NewBus()
+	svc := services.NewMetadataService(client, nil, &config.Config{}, logger, bus)
+
+	// Request an unregistered type — should return (nil, false)
+	got, ok := svc.GetEnricherFactory(enrichers.TypeMusicBrainz)
+	assert.False(t, ok, "unregistered factory should return false")
+	assert.Nil(t, got, "unregistered factory should return nil")
+}

--- a/internal/services/similar_artists_llm_test.go
+++ b/internal/services/similar_artists_llm_test.go
@@ -1,0 +1,102 @@
+package services_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"spotter/internal/config"
+	"spotter/internal/events"
+	"spotter/internal/llm"
+	"spotter/internal/services"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindSimilarArtists_LLMTimeout_ReturnsError(t *testing.T) {
+	client := setupSimilarArtistsTestDB(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	bus := events.NewBus()
+
+	// Create a mock server that simulates a timeout by taking longer than the context deadline
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{}
+	cfg.OpenAI.APIKey = "test-key"
+	cfg.OpenAI.BaseURL = srv.URL + "/v1"
+
+	svc := services.NewSimilarArtistsService(client, cfg, logger, bus)
+
+	user := similarArtistsCreateTestUser(t, client, "testuser")
+	artist := similarArtistsCreateTestArtist(t, client, user, "Test Artist", []string{"Rock"})
+	_ = similarArtistsCreateTestArtist(t, client, user, "Another Artist", []string{"Rock"})
+
+	// Use a context with a very short deadline to force a timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := svc.FindSimilarArtists(ctx, user.ID, artist.ID)
+	assert.Error(t, err, "FindSimilarArtists should return error on timeout")
+	assert.Contains(t, err.Error(), "failed to call OpenAI")
+}
+
+func TestFindSimilarArtists_LLMUnparseable_ReturnsParseError(t *testing.T) {
+	client := setupSimilarArtistsTestDB(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	bus := events.NewBus()
+
+	// Create a mock server that returns a valid API response with unparseable content
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := llm.ChatResponse{
+			ID:      "chatcmpl-test",
+			Object:  "chat.completion",
+			Created: time.Now().Unix(),
+			Model:   "gpt-4o",
+			Choices: []llm.ChatChoice{
+				{
+					Index: 0,
+					Message: struct {
+						Role    string `json:"role"`
+						Content string `json:"content"`
+					}{
+						Role:    "assistant",
+						Content: "this is not valid json at all {{{",
+					},
+					FinishReason: "stop",
+				},
+			},
+			Usage: &llm.ChatUsage{
+				PromptTokens:     100,
+				CompletionTokens: 50,
+				TotalTokens:      150,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{}
+	cfg.OpenAI.APIKey = "test-key"
+	cfg.OpenAI.BaseURL = srv.URL + "/v1"
+
+	svc := services.NewSimilarArtistsService(client, cfg, logger, bus)
+
+	user := similarArtistsCreateTestUser(t, client, "testuser2")
+	artist := similarArtistsCreateTestArtist(t, client, user, "Test Artist", []string{"Rock"})
+	_ = similarArtistsCreateTestArtist(t, client, user, "Another Artist", []string{"Rock"})
+
+	err := svc.FindSimilarArtists(context.Background(), user.ID, artist.ID)
+	require.Error(t, err, "FindSimilarArtists should return error on unparseable response")
+	assert.Contains(t, err.Error(), "failed to parse AI response")
+}

--- a/internal/services/sync_error_test.go
+++ b/internal/services/sync_error_test.go
@@ -1,0 +1,194 @@
+package services_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"spotter/ent/enttest"
+	"spotter/internal/config"
+	"spotter/internal/events"
+	"spotter/internal/providers"
+	"spotter/internal/services"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncer_GetActiveProviders_Error_ReturnsWithoutTouchingDB(t *testing.T) {
+	// When getActiveProviders returns an error (user not found), Sync should return the error
+	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	t.Cleanup(func() { client.Close() })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	bus := events.NewBus()
+	syncer := services.NewSyncer(client, &config.Config{}, logger, bus, nil)
+
+	// Create a user, then delete them so getActiveProviders fails on refresh
+	user, err := client.User.Create().SetUsername("testuser").Save(context.Background())
+	require.NoError(t, err)
+
+	// Register a mock provider that should never be called
+	mockProv := &mockProvider{providerType: providers.TypeSpotify}
+	syncer.Register(mockFactory(mockProv))
+
+	// Delete the user so the refresh query fails
+	require.NoError(t, client.User.DeleteOne(user).Exec(context.Background()))
+
+	err = syncer.Sync(context.Background(), user)
+	assert.Error(t, err, "Sync should return error when getActiveProviders fails")
+	assert.Contains(t, err.Error(), "failed to refresh user data")
+
+	// Verify no listens or playlists were created
+	listens, _ := client.Listen.Query().All(context.Background())
+	assert.Empty(t, listens, "no listens should be created on getActiveProviders failure")
+}
+
+func TestSyncer_ProviderError_TriggersBackoffRetriable(t *testing.T) {
+	// When a provider returns a retriable error, backoff state is recorded
+	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	t.Cleanup(func() { client.Close() })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	bus := events.NewBus()
+	syncer := services.NewSyncer(client, &config.Config{}, logger, bus, nil)
+
+	user, err := client.User.Create().SetUsername("testuser").Save(context.Background())
+	require.NoError(t, err)
+	_, err = client.SpotifyAuth.Create().
+		SetUser(user).
+		SetAccessToken("test").
+		SetRefreshToken("test").
+		SetExpiry(time.Now().Add(time.Hour)).
+		Save(context.Background())
+	require.NoError(t, err)
+
+	// Register mock provider that returns a retriable error (timeout)
+	mockProv := &mockProvider{
+		providerType: providers.TypeSpotify,
+		err:          fmt.Errorf("connection timeout"),
+	}
+	syncer.Register(mockFactory(mockProv))
+
+	// First sync — should not return error (Sync swallows per-provider errors)
+	err = syncer.Sync(context.Background(), user)
+	assert.NoError(t, err, "Sync should not surface per-provider errors")
+
+	// Second sync — the provider should be skipped due to backoff
+	err = syncer.Sync(context.Background(), user)
+	assert.NoError(t, err)
+}
+
+func TestSyncer_ProviderError_FatalNotRetried(t *testing.T) {
+	// When a provider returns a fatal error, it should be blocked from retry
+	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	t.Cleanup(func() { client.Close() })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	bus := events.NewBus()
+	syncer := services.NewSyncer(client, &config.Config{}, logger, bus, nil)
+
+	user, err := client.User.Create().SetUsername("testuser").Save(context.Background())
+	require.NoError(t, err)
+	_, err = client.SpotifyAuth.Create().
+		SetUser(user).
+		SetAccessToken("test").
+		SetRefreshToken("test").
+		SetExpiry(time.Now().Add(time.Hour)).
+		Save(context.Background())
+	require.NoError(t, err)
+
+	// Register mock provider that returns a fatal error (unauthorized)
+	fatalErr := services.NewHTTPStatusError(401, fmt.Errorf("token revoked"))
+	mockProv := &mockProvider{
+		providerType: providers.TypeSpotify,
+		err:          fatalErr,
+	}
+	syncer.Register(mockFactory(mockProv))
+
+	// First sync — triggers fatal error
+	err = syncer.Sync(context.Background(), user)
+	assert.NoError(t, err, "Sync should not surface per-provider errors")
+
+	// Second sync — provider should be skipped due to fatal backoff
+	err = syncer.Sync(context.Background(), user)
+	assert.NoError(t, err)
+}
+
+func TestSyncer_SyncRecentListens_GetActiveProviders_Error(t *testing.T) {
+	// SyncRecentListens should propagate getActiveProviders errors
+	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	t.Cleanup(func() { client.Close() })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	bus := events.NewBus()
+	syncer := services.NewSyncer(client, &config.Config{}, logger, bus, nil)
+
+	user, err := client.User.Create().SetUsername("testuser").Save(context.Background())
+	require.NoError(t, err)
+
+	// Delete user to force getActiveProviders to fail
+	require.NoError(t, client.User.DeleteOne(user).Exec(context.Background()))
+
+	err = syncer.SyncRecentListens(context.Background(), user)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to refresh user data")
+}
+
+func TestSyncer_SyncPlaylists_GetActiveProviders_Error(t *testing.T) {
+	// SyncPlaylists should propagate getActiveProviders errors
+	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	t.Cleanup(func() { client.Close() })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	bus := events.NewBus()
+	syncer := services.NewSyncer(client, &config.Config{}, logger, bus, nil)
+
+	user, err := client.User.Create().SetUsername("testuser").Save(context.Background())
+	require.NoError(t, err)
+
+	// Delete user to force getActiveProviders to fail
+	require.NoError(t, client.User.DeleteOne(user).Exec(context.Background()))
+
+	err = syncer.SyncPlaylists(context.Background(), user)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to refresh user data")
+}
+
+func TestSyncer_HistoryCallbackError_DoesNotPersistPartialData(t *testing.T) {
+	// When GetRecentListens returns an error, the provider is skipped
+	// and no partial data leaks
+	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	t.Cleanup(func() { client.Close() })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	bus := events.NewBus()
+	syncer := services.NewSyncer(client, &config.Config{}, logger, bus, nil)
+
+	user, err := client.User.Create().SetUsername("testuser").Save(context.Background())
+	require.NoError(t, err)
+	_, err = client.NavidromeAuth.Create().
+		SetUser(user).
+		SetPassword("testpassword").
+		Save(context.Background())
+	require.NoError(t, err)
+
+	// Register a provider that returns an error from GetRecentListens
+	failProv := &mockProvider{
+		providerType: providers.TypeNavidrome,
+		err:          fmt.Errorf("connection timeout"),
+	}
+	syncer.Register(mockFactory(failProv))
+
+	err = syncer.SyncRecentListens(context.Background(), user)
+	require.NoError(t, err) // syncHistory swallows per-provider errors
+
+	// Verify no listens were persisted
+	listens, err := client.Listen.Query().All(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, listens, "no listens should be created when provider fails")
+}

--- a/internal/vibes/seed_test.go
+++ b/internal/vibes/seed_test.go
@@ -1,0 +1,87 @@
+package vibes_test
+
+import (
+	"context"
+	"testing"
+
+	"spotter/ent"
+	"spotter/ent/enttest"
+	"spotter/internal/vibes"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupSeedTestDB(t *testing.T) *ent.Client {
+	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	t.Cleanup(func() { client.Close() })
+	return client
+}
+
+func createSeedTestUser(t *testing.T, client *ent.Client, username string) *ent.User {
+	u, err := client.User.Create().
+		SetUsername(username).
+		Save(context.Background())
+	require.NoError(t, err)
+	return u
+}
+
+func TestSeedDefaultDJs_CreatesExactly4DJs(t *testing.T) {
+	client := setupSeedTestDB(t)
+	user := createSeedTestUser(t, client, "testuser")
+
+	err := vibes.SeedDefaultDJs(context.Background(), client, user)
+	require.NoError(t, err)
+
+	djs, err := client.DJ.Query().All(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, djs, 4, "SeedDefaultDJs should create exactly 4 DJs")
+}
+
+func TestSeedDefaultDJs_AllFieldsPopulated(t *testing.T) {
+	client := setupSeedTestDB(t)
+	user := createSeedTestUser(t, client, "testuser")
+
+	err := vibes.SeedDefaultDJs(context.Background(), client, user)
+	require.NoError(t, err)
+
+	djs, err := client.DJ.Query().All(context.Background())
+	require.NoError(t, err)
+	require.Len(t, djs, 4)
+
+	for _, dj := range djs {
+		assert.NotEmpty(t, dj.GenresInclude, "DJ %q should have non-empty GenresInclude", dj.Name)
+		assert.NotEmpty(t, dj.Vibes, "DJ %q should have non-empty Vibes", dj.Name)
+		assert.NotEmpty(t, dj.SystemPrompt, "DJ %q should have non-empty SystemPrompt", dj.Name)
+	}
+}
+
+func TestSeedDefaultDJs_CalledTwice_NoPanic(t *testing.T) {
+	client := setupSeedTestDB(t)
+	user := createSeedTestUser(t, client, "testuser")
+
+	err := vibes.SeedDefaultDJs(context.Background(), client, user)
+	require.NoError(t, err)
+
+	// Second call should return an error (unique constraint on name+user) but not panic
+	err = vibes.SeedDefaultDJs(context.Background(), client, user)
+	assert.Error(t, err, "second call should fail due to unique constraint")
+
+	// Original 4 DJs should still be intact
+	djs, err := client.DJ.Query().All(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, djs, 4, "original 4 DJs should still exist")
+}
+
+func TestSeedDefaultDJs_DBUnavailable_ReturnsWrappedError(t *testing.T) {
+	client := setupSeedTestDB(t)
+	user := createSeedTestUser(t, client, "testuser")
+
+	// Close the DB to simulate unavailability
+	client.Close()
+
+	err := vibes.SeedDefaultDJs(context.Background(), client, user)
+	assert.Error(t, err, "should return error when DB is unavailable")
+	assert.Contains(t, err.Error(), "seeding DJ", "error should be wrapped with DJ context")
+}


### PR DESCRIPTION
## Summary
- Adds error-path tests for sync service (getActiveProviders failure, retriable/fatal backoff, history callback errors)
- Adds metadata service tests (GetEnricherFactory registered/unregistered)
- Adds vibes seed tests (SeedDefaultDJs creates 4 DJs, all fields populated, idempotency, DB unavailable)
- Adds similar artists LLM error tests (timeout returns error, unparseable response returns parse error)

Closes #276
Part of #269

## Test plan
- [x] All 14 new tests pass
- [x] Full `go test ./...` passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)