### PR TITLE
Extract chart init helpers, prune stale worktrees

### DIFF
--- a/internal/handlers/albums.go
+++ b/internal/handlers/albums.go
@@ -119,27 +119,10 @@ func (h *Handler) AlbumChart(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) getAlbumStats(ctx context.Context, userID int, a *ent.Album, timeframe string) *albums.AlbumStats {
 	stats := &albums.AlbumStats{
-		ListensByHour:      make([]components.ChartDataPoint, 24),
-		ListensByDayOfWeek: make([]components.ChartDataPoint, 7),
-		ListensByMonth:     make([]components.ChartDataPoint, 12),
+		ListensByHour:      components.InitializeHourlyStats(),
+		ListensByDayOfWeek: components.InitializeDailyStats(),
+		ListensByMonth:     components.InitializeMonthlyStats(),
 		TrackListens:       []components.ChartDataPoint{},
-	}
-
-	// Initialize hour labels
-	for i := 0; i < 24; i++ {
-		stats.ListensByHour[i] = components.ChartDataPoint{Label: strconv.Itoa(i), Value: 0}
-	}
-
-	// Initialize day labels
-	days := []string{"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"}
-	for i, day := range days {
-		stats.ListensByDayOfWeek[i] = components.ChartDataPoint{Label: day, Value: 0}
-	}
-
-	// Initialize month labels
-	months := []string{"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"}
-	for i, month := range months {
-		stats.ListensByMonth[i] = components.ChartDataPoint{Label: month, Value: 0}
 	}
 
 	// Build the query for this album's listens

--- a/internal/handlers/artists.go
+++ b/internal/handlers/artists.go
@@ -154,26 +154,9 @@ func (h *Handler) ArtistChart(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) getArtistStats(ctx context.Context, userID int, artistName string, timeframe string) *artists.ArtistStats {
 	stats := &artists.ArtistStats{
-		ListensByHour:      make([]components.ChartDataPoint, 24),
-		ListensByDayOfWeek: make([]components.ChartDataPoint, 7),
-		ListensByMonth:     make([]components.ChartDataPoint, 12),
-	}
-
-	// Initialize hour labels
-	for i := 0; i < 24; i++ {
-		stats.ListensByHour[i] = components.ChartDataPoint{Label: strconv.Itoa(i), Value: 0}
-	}
-
-	// Initialize day labels
-	days := []string{"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"}
-	for i, day := range days {
-		stats.ListensByDayOfWeek[i] = components.ChartDataPoint{Label: day, Value: 0}
-	}
-
-	// Initialize month labels
-	months := []string{"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"}
-	for i, month := range months {
-		stats.ListensByMonth[i] = components.ChartDataPoint{Label: month, Value: 0}
+		ListensByHour:      components.InitializeHourlyStats(),
+		ListensByDayOfWeek: components.InitializeDailyStats(),
+		ListensByMonth:     components.InitializeMonthlyStats(),
 	}
 
 	// Get all listens for this artist

--- a/internal/handlers/tracks.go
+++ b/internal/handlers/tracks.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"context"
 	"net/http"
-	"strconv"
 	"time"
 
 	"spotter/ent"
@@ -137,26 +136,9 @@ func (h *Handler) getPlaylistsWithTrack(ctx context.Context, userID int, trackID
 
 func (h *Handler) getTrackStats(ctx context.Context, userID int, t *ent.Track, timeframe string) *tracks.TrackStats {
 	stats := &tracks.TrackStats{
-		ListensByHour:      make([]components.ChartDataPoint, 24),
-		ListensByDayOfWeek: make([]components.ChartDataPoint, 7),
-		ListensByMonth:     make([]components.ChartDataPoint, 12),
-	}
-
-	// Initialize hour labels
-	for i := 0; i < 24; i++ {
-		stats.ListensByHour[i] = components.ChartDataPoint{Label: strconv.Itoa(i), Value: 0}
-	}
-
-	// Initialize day labels
-	days := []string{"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"}
-	for i, day := range days {
-		stats.ListensByDayOfWeek[i] = components.ChartDataPoint{Label: day, Value: 0}
-	}
-
-	// Initialize month labels
-	months := []string{"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"}
-	for i, month := range months {
-		stats.ListensByMonth[i] = components.ChartDataPoint{Label: month, Value: 0}
+		ListensByHour:      components.InitializeHourlyStats(),
+		ListensByDayOfWeek: components.InitializeDailyStats(),
+		ListensByMonth:     components.InitializeMonthlyStats(),
 	}
 
 	// Build query for this track's listens

--- a/internal/views/components/stats.go
+++ b/internal/views/components/stats.go
@@ -1,0 +1,32 @@
+package components
+
+import "strconv"
+
+// InitializeHourlyStats returns 24 pre-labelled zero-value ChartDataPoints for hours 0–23.
+func InitializeHourlyStats() []ChartDataPoint {
+	pts := make([]ChartDataPoint, 24)
+	for i := range pts {
+		pts[i] = ChartDataPoint{Label: strconv.Itoa(i), Value: 0}
+	}
+	return pts
+}
+
+// InitializeDailyStats returns 7 pre-labelled zero-value ChartDataPoints for Sun–Sat.
+func InitializeDailyStats() []ChartDataPoint {
+	days := []string{"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"}
+	pts := make([]ChartDataPoint, len(days))
+	for i, d := range days {
+		pts[i] = ChartDataPoint{Label: d, Value: 0}
+	}
+	return pts
+}
+
+// InitializeMonthlyStats returns 12 pre-labelled zero-value ChartDataPoints for Jan–Dec.
+func InitializeMonthlyStats() []ChartDataPoint {
+	months := []string{"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"}
+	pts := make([]ChartDataPoint, len(months))
+	for i, m := range months {
+		pts[i] = ChartDataPoint{Label: m, Value: 0}
+	}
+	return pts
+}


### PR DESCRIPTION
Extracts the identical hour/day/month chart label initialization from three handlers into shared helpers in `internal/views/components/stats.go`:

- `InitializeHourlyStats()` — 24 points, labels "0"–"23"
- `InitializeDailyStats()` — 7 points, labels "Sun"–"Sat"
- `InitializeMonthlyStats()` — 12 points, labels "Jan"–"Dec"

Also runs `git worktree prune` and removes 24 stale `.claude/worktrees/` directories left from the completed spec compliance and DRY sprint cycles.

Closes #280
Part of #271