### PR TITLE
Rename /design: namespace to /sdd:

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,30 +1,30 @@
 ## Architecture Context
 
-This project uses the [design plugin](https://github.com/joestump/claude-plugin-design) for architecture governance.
+This project uses the [SDD plugin](https://github.com/joestump/claude-plugin-sdd) for architecture governance.
 
 - Architecture Decision Records are in `docs/adrs/`
 - Specifications are in `docs/openspec/specs/`
 
-### Design Plugin Skills
+### SDD Skills
 
 | Skill | Purpose |
 |-------|---------|
-| `/design:adr` | Create a new Architecture Decision Record |
-| `/design:spec` | Create a new specification |
-| `/design:list` | List all ADRs and specs with status |
-| `/design:status` | Update the status of an ADR or spec |
-| `/design:docs` | Generate a documentation site |
-| `/design:init` | Set up CLAUDE.md with architecture context |
-| `/design:prime` | Load architecture context into session |
-| `/design:check` | Quick-check code against ADRs and specs for drift |
-| `/design:audit` | Comprehensive design artifact alignment audit |
-| `/design:discover` | Discover implicit architecture from existing code |
-| `/design:plan` | Break a spec into trackable issues with project grouping and branch conventions |
-| `/design:organize` | Retroactively group issues into tracker-native projects |
-| `/design:enrich` | Add branch naming and PR conventions to existing issues |
-| `/design:work` | Pick up tracker issues and implement them in parallel using git worktrees |
+| `/sdd:adr` | Create a new Architecture Decision Record |
+| `/sdd:spec` | Create a new specification |
+| `/sdd:list` | List all ADRs and specs with status |
+| `/sdd:status` | Update the status of an ADR or spec |
+| `/sdd:docs` | Generate a documentation site |
+| `/sdd:init` | Set up CLAUDE.md with architecture context |
+| `/sdd:prime` | Load architecture context into session |
+| `/sdd:check` | Quick-check code against ADRs and specs for drift |
+| `/sdd:audit` | Comprehensive design artifact alignment audit |
+| `/sdd:discover` | Discover implicit architecture from existing code |
+| `/sdd:plan` | Break a spec into trackable issues with project grouping and branch conventions |
+| `/sdd:organize` | Retroactively group issues into tracker-native projects |
+| `/sdd:enrich` | Add branch naming and PR conventions to existing issues |
+| `/sdd:work` | Pick up tracker issues and implement them in parallel using git worktrees |
 
-Run `/design:prime [topic]` at the start of a session to load relevant ADRs and specs into context.
+Run `/sdd:prime [topic]` at the start of a session to load relevant ADRs and specs into context.
 
 ### Governing Comments
 
@@ -34,13 +34,13 @@ When implementing code governed by ADRs or specs, leave comments referencing the
 // Governing: ADR-0001 (chose JWT over sessions), SPEC-0003 REQ "Token Validation"
 ```
 
-These comments help future sessions (and `/design:check`) trace implementation back to decisions.
+These comments help future sessions (and `/sdd:check`) trace implementation back to decisions.
 
 ### Workflow
 
-1. **Decide**: `/design:adr` — record the architectural decision
-2. **Specify**: `/design:spec` — formalize requirements with RFC 2119 language
-3. **Plan**: `/design:plan` — break the spec into trackable issues in your tracker
-4. **Enrich**: `/design:organize` and `/design:enrich` — add projects and branch conventions
-5. **Build**: `/design:work` — pick up issues and implement in parallel using git worktrees
-6. **Validate**: `/design:check` and `/design:audit` to catch drift
+1. **Decide**: `/sdd:adr` — record the architectural decision
+2. **Specify**: `/sdd:spec` — formalize requirements with RFC 2119 language
+3. **Plan**: `/sdd:plan` — break the spec into trackable issues in your tracker
+4. **Enrich**: `/sdd:organize` and `/sdd:enrich` — add projects and branch conventions
+5. **Build**: `/sdd:work` — pick up issues and implement in parallel using git worktrees
+6. **Validate**: `/sdd:check` and `/sdd:audit` to catch drift


### PR DESCRIPTION
## Summary

Mechanical sweep updating references from the old `/design:` plugin namespace to `/sdd:` (Spec-Driven Development). The plugin was renamed in joestump/claude-plugin-sdd#75 because Anthropic shipped an official `design` plugin that collides with the namespace.

Doc-only changes:
- `/design:*` → `/sdd:*`
- `claude-plugin-design` → `claude-plugin-sdd`
- "design plugin" / "Design Plugin" → "SDD plugin" / "SDD Plugin"
- `### Design Plugin Configuration` heading → `### SDD Configuration`

## Test plan

- [x] `git diff` reviewed — only namespace/branding strings changed
- [ ] Run `/sdd:prime` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)