### PR TITLE
Fix lint-docs Makefile path: website → docs-site

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ deps: ## Install all dependencies (Go, Node, tools, docs)
 	@echo "Installing Node dependencies..."
 	npm install
 	@echo "Installing documentation dependencies..."
-	cd website && npm install
+	cd docs-site && npm install
 	@echo "✓ All dependencies installed"
 
 ci-deps: ## Install CI dependencies (minimal, no dev tools)
@@ -160,7 +160,7 @@ lint-md: ## Run markdownlint on Markdown files
 
 lint-docs: ## Build Docusaurus docs (checks for broken links)
 	@echo "Building documentation to check for broken links..."
-	@cd website && npm run build
+	@cd docs-site && npm run build
 	@echo "✓ Documentation build passed"
 
 lint-go: generate ## Run golangci-lint on Go code


### PR DESCRIPTION
## Summary

The Makefile's \`deps\` and \`lint-docs\` targets reference a non-existent \`website/\` directory. The Docusaurus site lives at \`docs-site/\`. Every other Makefile target and both CI workflows already use the correct path. \`lint-docs\` is invoked by \`make lint\`, so this has been failing on every CI run since the docs site was added.

## Test plan

- [x] Visual diff verifies only the two stale paths change
- [ ] CI \`lint\` job goes green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)