### PR TITLE
Story #324: Consolidate configuration into Viper Config struct; make Lidarr optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,20 @@ SPOTTER_SECURITY_SECURE_COOKIES=true
 # Navidrome Configuration (REQUIRED)
 SPOTTER_NAVIDROME_BASE_URL=https://your-navidrome-instance.com
 
+# Server - Public base URL of this Spotter instance (optional - used in
+# sync-failure notification email links, e.g. https://spotter.example.com)
+# SPOTTER_SERVER_BASE_URL=
+
+# Graceful shutdown budget (optional - Go duration, default 30s)
+# SPOTTER_SHUTDOWN_TIMEOUT=30s
+
+# Maximum concurrent background jobs (optional - default 10)
+# SPOTTER_MAX_CONCURRENT_JOBS=10
+
+# Sync - Initial listen-history lookback for users with no prior listens
+# (optional - Go duration, default 720h = 30 days)
+# SPOTTER_SYNC_HISTORY_LOOKBACK=720h
+
 # Spotify Configuration (optional - for playlist sync)
 SPOTTER_SPOTIFY_CLIENT_ID=
 SPOTTER_SPOTIFY_CLIENT_SECRET=
@@ -32,9 +46,10 @@ SPOTTER_OPENAI_MODEL=gpt-4o
 # Fanart.tv Configuration (optional - for artist/album images)
 SPOTTER_METADATA_FANART_API_KEY=
 
-# Lidarr Configuration (optional)
-SPOTTER_LIDARR_BASE_URL=https://your-lidarr-instance.com
-SPOTTER_LIDARR_API_KEY=
+# Lidarr Configuration (optional - set BOTH to enable the Lidarr enricher
+# and submission queue; leave BOTH unset to disable Lidarr entirely)
+# SPOTTER_LIDARR_BASE_URL=https://your-lidarr-instance.com
+# SPOTTER_LIDARR_API_KEY=
 
 # Lidarr Submission Queue (optional - controls backpressure)
 # SPOTTER_LIDARR_QUEUE_MAX=50

--- a/cmd/admin/main.go
+++ b/cmd/admin/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 
+	"spotter/internal/config"
 	"spotter/internal/crypto"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -48,23 +49,20 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Governing: ADR-0023 (multi-database support)
-	// Determine database driver and DSN from environment or flags.
-	driver := os.Getenv("SPOTTER_DATABASE_DRIVER")
-	if driver == "" {
-		driver = driverSQLite3
+	// Governing: ADR-0023 (multi-database support), ADR-0009 (Viper configuration)
+	// Determine database driver and DSN via config.Load() — the same Viper-backed
+	// loader the server uses (SPOTTER_DATABASE_DRIVER / SPOTTER_DATABASE_SOURCE),
+	// including driver validation and driver-specific default sources. The --db
+	// flag still overrides the configured DSN.
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to load config: %v\n", err)
+		os.Exit(1)
 	}
-	dsn := os.Getenv("SPOTTER_DATABASE_SOURCE")
-	if dsn == "" {
-		dsn = "file:spotter.db?cache=shared&_fk=1"
-	}
+	driver := cfg.Database.Driver
+	dsn := cfg.Database.Source
 	if *dbDSNFlag != "" {
 		dsn = *dbDSNFlag
-	}
-
-	if driver != driverSQLite3 && driver != "postgres" && driver != "mysql" {
-		fmt.Fprintf(os.Stderr, "Error: unsupported SPOTTER_DATABASE_DRIVER %q (must be sqlite3, postgres, or mysql)\n", driver)
-		os.Exit(1)
 	}
 
 	if err := run(*oldKeyHex, *newKeyHex, driver, dsn); err != nil {

--- a/cmd/admin/main.go
+++ b/cmd/admin/main.go
@@ -49,14 +49,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Governing: ADR-0023 (multi-database support), ADR-0009 (Viper configuration)
-	// Determine database driver and DSN via config.Load() — the same Viper-backed
-	// loader the server uses (SPOTTER_DATABASE_DRIVER / SPOTTER_DATABASE_SOURCE),
-	// including driver validation and driver-specific default sources. The --db
-	// flag still overrides the configured DSN.
-	cfg, err := config.Load()
+	// Governing: ADR-0023 (multi-database support), ADR-0009 (Viper configuration), SPEC key-rotation
+	// Determine database driver and DSN via config.LoadDatabase() — the same
+	// Viper-backed loader the server uses (SPOTTER_DATABASE_DRIVER /
+	// SPOTTER_DATABASE_SOURCE), including driver validation and driver-specific
+	// default sources, but scoped to database config only so rotate-key can run
+	// standalone without full server configuration (SPEC key-rotation Scenario 1).
+	// The --db flag still overrides the configured DSN.
+	cfg, err := config.LoadDatabase()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: failed to load config: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Error: failed to load database config: %v\n", err)
 		os.Exit(1)
 	}
 	driver := cfg.Database.Driver

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -155,7 +154,12 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	mustRegisterEnricher(enrichers.TypeLidarr, enricherLidarr.New(logger, cfg, client))
+	// Governing: ADR-0015 (pluggable enricher registry), ADR-0009 (Lidarr optional — enricher skipped when unconfigured)
+	if cfg.IsLidarrEnabled() {
+		mustRegisterEnricher(enrichers.TypeLidarr, enricherLidarr.New(logger, cfg, client))
+	} else {
+		logger.Info("lidarr enricher disabled (lidarr not configured)")
+	}
 	mustRegisterEnricher(enrichers.TypeMusicBrainz, enricherMusicbrainz.New(logger, cfg))
 	mustRegisterEnricher(enrichers.TypeNavidrome, enricherNavidrome.New(logger, cfg))
 	mustRegisterEnricher(enrichers.TypeSpotify, enricherSpotify.New(logger, cfg))
@@ -190,21 +194,13 @@ func main() {
 
 	// Governing: SPEC graceful-shutdown REQ-TMO-001 (30s default shutdown budget)
 	// Governing: SPEC graceful-shutdown REQ-TMO-005 (configurable shutdown timeout)
-	shutdownTimeout := 30 * time.Second
-	if s := os.Getenv("SPOTTER_SHUTDOWN_TIMEOUT"); s != "" {
-		if d, err := time.ParseDuration(s); err == nil {
-			shutdownTimeout = d
-		}
-	}
+	// Governing: ADR-0009 (Viper configuration — SPOTTER_SHUTDOWN_TIMEOUT read via config, not os.Getenv)
+	shutdownTimeout := cfg.GetShutdownTimeout()
 
 	// Governing: SPEC graceful-shutdown REQ-SEM-001 through REQ-SEM-004 (bounded concurrency semaphore)
 	// Governing: SPEC graceful-shutdown REQ-SEM-002 (configurable semaphore capacity, default 10)
-	maxJobs := 10
-	if s := os.Getenv("SPOTTER_MAX_CONCURRENT_JOBS"); s != "" {
-		if n, err := strconv.Atoi(s); err == nil && n > 0 {
-			maxJobs = n
-		}
-	}
+	// Governing: ADR-0009 (Viper configuration — SPOTTER_MAX_CONCURRENT_JOBS read via config, not os.Getenv)
+	maxJobs := cfg.GetMaxConcurrentJobs()
 	sem := make(chan struct{}, maxJobs)
 
 	// Governing: SPEC graceful-shutdown REQ-WG-001 (single shared WaitGroup for all per-user goroutines)
@@ -414,8 +410,9 @@ func main() {
 	}()
 
 	// Governing: SPEC-0017 REQ "Background Submitter Goroutine", ADR-0029, ADR-0013
+	// Governing: ADR-0009 (Lidarr optional — submitter skipped when unconfigured)
 	// Background Lidarr Queue Submitter (only if Lidarr is configured)
-	if cfg.Lidarr.BaseURL != "" && cfg.Lidarr.APIKey != "" {
+	if cfg.IsLidarrEnabled() {
 		lidarrSubmitter := services.NewLidarrSubmitter(client, cfg, logger)
 		wg.Add(1)
 		go func() {

--- a/docs-site/docs/getting-started/configuration.md
+++ b/docs-site/docs/getting-started/configuration.md
@@ -26,6 +26,9 @@ Spotter is configured using environment variables. You can set these in your she
 | :--- | :--- | :--- |
 | `SPOTTER_SERVER_PORT` | The HTTP port the server listens on | `8080` |
 | `SPOTTER_SERVER_HOST` | The host address to bind to | `0.0.0.0` |
+| `SPOTTER_SERVER_BASE_URL` | Public base URL of this Spotter instance (used in sync-failure notification email links, e.g. `https://spotter.example.com`) | *None* |
+| `SPOTTER_SHUTDOWN_TIMEOUT` | Graceful shutdown budget (Go duration format) | `30s` |
+| `SPOTTER_MAX_CONCURRENT_JOBS` | Maximum concurrent per-user background jobs | `10` |
 
 ## Security Configuration
 
@@ -59,6 +62,7 @@ SPOTTER_DATABASE_SOURCE=host=localhost port=5432 dbname=spotter user=spotter pas
 | Variable | Description | Default |
 | :--- | :--- | :--- |
 | `SPOTTER_SYNC_INTERVAL` | How often to sync data from providers (Go duration format) | `5m` |
+| `SPOTTER_SYNC_HISTORY_LOOKBACK` | Initial listen-history window for users with no prior listens (Go duration format) | `720h` (30 days) |
 
 ## Theme Configuration
 
@@ -86,6 +90,8 @@ SPOTTER_DATABASE_SOURCE=host=localhost port=5432 dbname=spotter user=spotter pas
 | `SPOTTER_LASTFM_REDIRECT_URL` | Callback URL for Last.fm auth | *None* |
 
 ### Lidarr (Optional)
+
+Lidarr is entirely optional. When neither `SPOTTER_LIDARR_BASE_URL` nor `SPOTTER_LIDARR_API_KEY` is set, Spotter starts normally and skips the Lidarr metadata enricher and the Lidarr submission queue. Setting only one of the two is a configuration error — set both to enable Lidarr, or neither to disable it.
 
 | Variable | Description | Default |
 | :--- | :--- | :--- |
@@ -173,6 +179,11 @@ SPOTTER_OPENAI_API_KEY=sk-your-openai-api-key
 # ===================
 SPOTTER_SERVER_PORT=8080
 SPOTTER_SERVER_HOST=0.0.0.0
+# Public base URL (used in notification email links)
+# SPOTTER_SERVER_BASE_URL=https://spotter.example.com
+# Graceful shutdown budget and background job concurrency
+# SPOTTER_SHUTDOWN_TIMEOUT=30s
+# SPOTTER_MAX_CONCURRENT_JOBS=10
 
 # ===================
 # Security Configuration
@@ -198,6 +209,8 @@ SPOTTER_DATABASE_SOURCE=host=localhost port=5432 dbname=spotter user=spotter pas
 # Sync Configuration
 # ===================
 SPOTTER_SYNC_INTERVAL=5m
+# Initial history window for users with no prior listens (default 720h = 30 days)
+# SPOTTER_SYNC_HISTORY_LOOKBACK=720h
 
 # ===================
 # Theme Configuration

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/spf13/viper"
 )
@@ -110,12 +111,19 @@ type Config struct {
 	Server struct {
 		Port              string `mapstructure:"port"`
 		Host              string `mapstructure:"host"`
+		BaseURL           string `mapstructure:"base_url"`            // Governing: ADR-0026, SPEC-0015 (public base URL used in sync-failure email links)
 		ReadHeaderTimeout string `mapstructure:"read_header_timeout"` // Duration string for read header timeout (default: "10s")
 		ReadTimeout       string `mapstructure:"read_timeout"`        // Duration string for read timeout (default: "30s")
 		WriteTimeout      string `mapstructure:"write_timeout"`       // Duration string for write timeout (default: "60s")
 		IdleTimeout       string `mapstructure:"idle_timeout"`        // Duration string for idle timeout (default: "120s")
 	} `mapstructure:"server"`
-	Navidrome struct {
+	// Governing: ADR-0009 (Viper configuration), SPEC graceful-shutdown REQ-TMO-005 (configurable shutdown timeout)
+	// ShutdownTimeout is the graceful shutdown budget (SPOTTER_SHUTDOWN_TIMEOUT, default "30s").
+	ShutdownTimeout string `mapstructure:"shutdown_timeout"`
+	// Governing: ADR-0009 (Viper configuration), SPEC graceful-shutdown REQ-SEM-002 (configurable semaphore capacity)
+	// MaxConcurrentJobs bounds concurrent per-user background jobs (SPOTTER_MAX_CONCURRENT_JOBS, default 10).
+	MaxConcurrentJobs int `mapstructure:"max_concurrent_jobs"`
+	Navidrome         struct {
 		BaseURL string `mapstructure:"base_url"`
 	} `mapstructure:"navidrome"`
 	// Governing: SPEC-0017 REQ "Configuration", ADR-0029
@@ -127,6 +135,9 @@ type Config struct {
 	} `mapstructure:"lidarr"`
 	Sync struct {
 		Interval string `mapstructure:"interval"`
+		// Governing: SPEC listen-playlist-sync REQ-SYNC-020 (configurable initial history lookback)
+		// HistoryLookback is the initial history window for users with no prior listens (default: "720h" = 30 days).
+		HistoryLookback string `mapstructure:"history_lookback"`
 	} `mapstructure:"sync"`
 	Theme struct {
 		Available string `mapstructure:"available"` // Comma-separated list of DaisyUI theme names
@@ -191,17 +202,25 @@ func (c *Config) AvailableThemes() []string {
 
 // MetadataEnricherOrder returns the list of enrichers in the configured order.
 // Falls back to default order if not configured.
+// Governing: ADR-0015 (pluggable enricher registry), ADR-0009 (Lidarr optional —
+// the lidarr enricher is filtered out when Lidarr is unconfigured).
 func (c *Config) MetadataEnricherOrder() []string {
+	var parts []string
 	if c.Metadata.Order == "" {
-		return []string{"musicbrainz", "lidarr", "navidrome", "spotify", "lastfm", "fanart", "openai"}
+		parts = []string{"musicbrainz", "lidarr", "navidrome", "spotify", "lastfm", "fanart", "openai"}
+	} else {
+		parts = strings.Split(c.Metadata.Order, ",")
 	}
-	parts := strings.Split(c.Metadata.Order, ",")
 	result := make([]string, 0, len(parts))
 	for _, p := range parts {
 		p = strings.TrimSpace(strings.ToLower(p))
-		if p != "" {
-			result = append(result, p)
+		if p == "" {
+			continue
 		}
+		if p == "lidarr" && !c.IsLidarrEnabled() {
+			continue
+		}
+		result = append(result, p)
 	}
 	return result
 }
@@ -209,6 +228,47 @@ func (c *Config) MetadataEnricherOrder() []string {
 // IsOpenAIEnabled returns true if OpenAI API key is configured.
 func (c *Config) IsOpenAIEnabled() bool {
 	return c.OpenAI.APIKey != ""
+}
+
+// Governing: ADR-0009 (Viper configuration), SPEC-0017 REQ "Background Submitter Goroutine" (submitter only starts if Lidarr is configured)
+// IsLidarrEnabled returns true if Lidarr is fully configured (base URL and API key).
+// Lidarr is optional: when unconfigured, the Lidarr enricher and submitter are skipped.
+func (c *Config) IsLidarrEnabled() bool {
+	return c.Lidarr.BaseURL != "" && c.Lidarr.APIKey != ""
+}
+
+// Governing: ADR-0009 (Viper configuration), SPEC graceful-shutdown REQ-TMO-001, REQ-TMO-005
+// GetShutdownTimeout returns the graceful shutdown budget, falling back to 30s
+// when unset or unparsable.
+func (c *Config) GetShutdownTimeout() time.Duration {
+	if c.ShutdownTimeout != "" {
+		if d, err := time.ParseDuration(c.ShutdownTimeout); err == nil {
+			return d
+		}
+	}
+	return 30 * time.Second
+}
+
+// Governing: ADR-0009 (Viper configuration), SPEC graceful-shutdown REQ-SEM-002
+// GetMaxConcurrentJobs returns the background job semaphore capacity, falling
+// back to 10 when unset or non-positive.
+func (c *Config) GetMaxConcurrentJobs() int {
+	if c.MaxConcurrentJobs > 0 {
+		return c.MaxConcurrentJobs
+	}
+	return 10
+}
+
+// Governing: SPEC listen-playlist-sync REQ-SYNC-020 (configurable initial history lookback)
+// GetSyncHistoryLookback returns the initial history window for users with no
+// prior listens, falling back to 720h (30 days) when unset or unparsable.
+func (c *Config) GetSyncHistoryLookback() time.Duration {
+	if c.Sync.HistoryLookback != "" {
+		if d, err := time.ParseDuration(c.Sync.HistoryLookback); err == nil {
+			return d
+		}
+	}
+	return 720 * time.Hour
 }
 
 // GetVibesModel returns the model to use for vibes generation.
@@ -269,11 +329,18 @@ func Load() (*Config, error) {
 	v.SetDefault("security.auth_rate_limit", 10)  // Login attempts per minute per IP
 	v.SetDefault("server.port", "8080")
 	v.SetDefault("server.host", "0.0.0.0")
+	// Governing: ADR-0026, SPEC-0015 (public base URL used in sync-failure email links)
+	v.SetDefault("server.base_url", "")
 	v.SetDefault("server.read_header_timeout", "10s")
 	v.SetDefault("server.read_timeout", "30s")
 	v.SetDefault("server.write_timeout", "60s")
 	v.SetDefault("server.idle_timeout", "120s")
+	// Governing: SPEC graceful-shutdown REQ-TMO-005, REQ-SEM-002 (moved from raw os.Getenv per ADR-0009)
+	v.SetDefault("shutdown_timeout", "30s")
+	v.SetDefault("max_concurrent_jobs", 10)
 	v.SetDefault("sync.interval", "5m")
+	// Governing: SPEC listen-playlist-sync REQ-SYNC-020 (configurable initial history lookback, 30 days)
+	v.SetDefault("sync.history_lookback", "720h")
 	v.SetDefault("theme.available", "light,dark,cupcake")
 	v.SetDefault("theme.default", "dark")
 	v.SetDefault("database.driver", "sqlite3")
@@ -373,11 +440,12 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("navidrome.base_url is required")
 	}
 
-	if cfg.Lidarr.BaseURL == "" {
-		return nil, fmt.Errorf("lidarr.base_url is required")
-	}
-	if cfg.Lidarr.APIKey == "" {
-		return nil, fmt.Errorf("lidarr.api_key is required")
+	// Governing: ADR-0009 (Viper configuration), SPEC-0014 (compose scenarios MUST start without Lidarr),
+	// SPEC-0017 REQ "Background Submitter Goroutine" (submitter only starts if Lidarr is configured)
+	// Lidarr is optional: validation only rejects partial configuration (one of the
+	// two settings without the other), never the fully-unset case.
+	if (cfg.Lidarr.BaseURL == "") != (cfg.Lidarr.APIKey == "") {
+		return nil, fmt.Errorf("lidarr.base_url and lidarr.api_key must both be set to enable Lidarr (or both left unset to disable it)")
 	}
 
 	if cfg.OpenAI.APIKey == "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"time"
 
@@ -119,9 +120,16 @@ type Config struct {
 	} `mapstructure:"server"`
 	// Governing: ADR-0009 (Viper configuration), SPEC graceful-shutdown REQ-TMO-005 (configurable shutdown timeout)
 	// ShutdownTimeout is the graceful shutdown budget (SPOTTER_SHUTDOWN_TIMEOUT, default "30s").
+	// CONSTRAINT: this key is deliberately top-level (not namespaced under server.*)
+	// because the env var name SPOTTER_SHUTDOWN_TIMEOUT predates config consolidation
+	// (SPEC graceful-shutdown REQ-TMO-005 names it) and must keep working; with the
+	// dot-to-underscore replacer, only a top-level "shutdown_timeout" key maps to it.
 	ShutdownTimeout string `mapstructure:"shutdown_timeout"`
 	// Governing: ADR-0009 (Viper configuration), SPEC graceful-shutdown REQ-SEM-002 (configurable semaphore capacity)
 	// MaxConcurrentJobs bounds concurrent per-user background jobs (SPOTTER_MAX_CONCURRENT_JOBS, default 10).
+	// CONSTRAINT: top-level for the same reason as ShutdownTimeout — the published
+	// env var name SPOTTER_MAX_CONCURRENT_JOBS (SPEC graceful-shutdown REQ-SEM-002)
+	// must remain stable.
 	MaxConcurrentJobs int `mapstructure:"max_concurrent_jobs"`
 	Navidrome         struct {
 		BaseURL string `mapstructure:"base_url"`
@@ -222,6 +230,12 @@ func (c *Config) MetadataEnricherOrder() []string {
 		}
 		result = append(result, p)
 	}
+	if len(result) == 0 && len(parts) > 0 {
+		// Filtering unconfigured enrichers emptied the order entirely — metadata
+		// enrichment will be a silent no-op, which is almost certainly not intended.
+		slog.Warn("metadata enricher order is empty after filtering unconfigured enrichers; metadata enrichment will do nothing",
+			"configured_order", c.Metadata.Order)
+	}
 	return result
 }
 
@@ -239,10 +253,11 @@ func (c *Config) IsLidarrEnabled() bool {
 
 // Governing: ADR-0009 (Viper configuration), SPEC graceful-shutdown REQ-TMO-001, REQ-TMO-005
 // GetShutdownTimeout returns the graceful shutdown budget, falling back to 30s
-// when unset or unparsable.
+// when unset, unparsable, or non-positive (a zero or negative budget would mean
+// zero-grace shutdown).
 func (c *Config) GetShutdownTimeout() time.Duration {
 	if c.ShutdownTimeout != "" {
-		if d, err := time.ParseDuration(c.ShutdownTimeout); err == nil {
+		if d, err := time.ParseDuration(c.ShutdownTimeout); err == nil && d > 0 {
 			return d
 		}
 	}
@@ -261,10 +276,12 @@ func (c *Config) GetMaxConcurrentJobs() int {
 
 // Governing: SPEC listen-playlist-sync REQ-SYNC-020 (configurable initial history lookback)
 // GetSyncHistoryLookback returns the initial history window for users with no
-// prior listens, falling back to 720h (30 days) when unset or unparsable.
+// prior listens, falling back to 720h (30 days) when unset, unparsable, or
+// non-positive (a negative lookback would put the since watermark in the
+// future and the first sync would fetch nothing).
 func (c *Config) GetSyncHistoryLookback() time.Duration {
 	if c.Sync.HistoryLookback != "" {
-		if d, err := time.ParseDuration(c.Sync.HistoryLookback); err == nil {
+		if d, err := time.ParseDuration(c.Sync.HistoryLookback); err == nil && d > 0 {
 			return d
 		}
 	}
@@ -314,7 +331,12 @@ func (c *Config) GetEncryptionKeyBytes() ([]byte, error) {
 	return key, nil
 }
 
-func Load() (*Config, error) {
+// newViper creates the Viper instance shared by Load and LoadDatabase:
+// SPOTTER_* prefix, dot-to-underscore key replacer, automatic env binding,
+// and every default registered (Viper only picks up env vars during Unmarshal
+// for keys that have a registered default).
+// Governing: ADR-0009 (Viper configuration)
+func newViper() *viper.Viper {
 	v := viper.New()
 
 	v.SetEnvPrefix("SPOTTER")
@@ -408,24 +430,85 @@ func Load() (*Config, error) {
 	v.SetDefault("metadata.images.max_height", 1000)
 	v.SetDefault("metadata.ai.prompts_directory", "./data/prompts")
 
-	var cfg Config
-	if err := v.Unmarshal(&cfg); err != nil {
-		return nil, err
-	}
+	return v
+}
 
-	// Governing: SPEC-0014 REQ "Driver Validation", ADR-0023
+// validateAndDefaultDatabase validates the database driver and applies the
+// driver-specific default DSN when the source is unset (or still the sqlite
+// default from Viper). Shared by Load and LoadDatabase.
+// Governing: SPEC-0014 REQ "Driver Validation", REQ "Driver-Specific Default Source", ADR-0023
+func validateAndDefaultDatabase(cfg *Config) error {
 	validDrivers := map[string]bool{"sqlite3": true, "postgres": true, "mysql": true}
 	if !validDrivers[cfg.Database.Driver] {
-		return nil, fmt.Errorf("unsupported database driver %q: must be one of sqlite3, postgres, mysql", cfg.Database.Driver)
+		return fmt.Errorf("unsupported database driver %q: must be one of sqlite3, postgres, mysql", cfg.Database.Driver)
 	}
 
-	// Governing: SPEC-0014 REQ "Driver-Specific Default Source", ADR-0023
 	const sqliteDefault = "file:spotter.db?cache=shared&_fk=1"
 	if cfg.Database.Driver == "postgres" && (cfg.Database.Source == "" || cfg.Database.Source == sqliteDefault) {
 		cfg.Database.Source = "host=localhost port=5432 dbname=spotter sslmode=disable"
 	} else if cfg.Database.Driver == "mysql" && (cfg.Database.Source == "" || cfg.Database.Source == sqliteDefault) {
 		cfg.Database.Source = "spotter:spotter@tcp(localhost:3306)/spotter?parseTime=true&charset=utf8mb4"
 	}
+	return nil
+}
+
+// LoadDatabase loads only the database-scoped configuration (driver + source)
+// through the same Viper setup as Load — SPOTTER_DATABASE_DRIVER and
+// SPOTTER_DATABASE_SOURCE with driver validation and driver-specific default
+// DSNs — but skips full-server validation (Navidrome, OpenAI, security keys).
+// Standalone tooling like `spotter-admin rotate-key` uses this so it can run
+// with only database env vars set (SPEC key-rotation Scenario 1) while still
+// honoring ADR-0009's "no hand-rolled os.Getenv" rule.
+// Governing: ADR-0009 (Viper configuration), ADR-0023 (multi-database support), SPEC key-rotation
+func LoadDatabase() (*Config, error) {
+	v := newViper()
+
+	var cfg Config
+	cfg.Database.Driver = v.GetString("database.driver")
+	cfg.Database.Source = v.GetString("database.source")
+
+	// Viper treats empty-string env vars as "set", overriding defaults (see
+	// ADR-0009 consequences); fall back to the sqlite defaults explicitly,
+	// matching the pre-consolidation admin behavior.
+	if cfg.Database.Driver == "" {
+		cfg.Database.Driver = "sqlite3"
+	}
+	if cfg.Database.Source == "" && cfg.Database.Driver == "sqlite3" {
+		cfg.Database.Source = "file:spotter.db?cache=shared&_fk=1"
+	}
+
+	if err := validateAndDefaultDatabase(&cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func Load() (*Config, error) {
+	v := newViper()
+
+	// Governing: ADR-0009 (fail fast with clear error messages)
+	// Pre-validate max_concurrent_jobs so a non-numeric SPOTTER_MAX_CONCURRENT_JOBS
+	// produces a clear error instead of a raw mapstructure decode failure.
+	if s := strings.TrimSpace(v.GetString("max_concurrent_jobs")); s != "" {
+		if _, err := strconv.Atoi(s); err != nil {
+			return nil, fmt.Errorf("max_concurrent_jobs must be an integer (set SPOTTER_MAX_CONCURRENT_JOBS), got %q", s)
+		}
+	}
+
+	var cfg Config
+	if err := v.Unmarshal(&cfg); err != nil {
+		return nil, err
+	}
+
+	// Governing: SPEC-0014 REQ "Driver Validation", REQ "Driver-Specific Default Source", ADR-0023
+	if err := validateAndDefaultDatabase(&cfg); err != nil {
+		return nil, err
+	}
+
+	// Governing: ADR-0026, SPEC-0015 (base URL is joined with paths in email links)
+	// Normalize server.base_url: strip trailing slashes so consumers can safely
+	// append absolute paths like /preferences/providers.
+	cfg.Server.BaseURL = strings.TrimRight(cfg.Server.BaseURL, "/")
 
 	// Apply defaults for OpenAI config when env vars are empty strings
 	// (Viper treats empty string env vars as "set", overriding defaults)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -357,6 +357,79 @@ func TestMetadataEnricherOrderExcludesLidarrWhenUnconfigured(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, cfg.MetadataEnricherOrder(), "lidarr")
 	})
+
+	t.Run("order of only lidarr yields empty order when unconfigured", func(t *testing.T) {
+		setRequiredEnvVars(t)
+		t.Setenv("SPOTTER_METADATA_ORDER", "lidarr")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		// Enrichment becomes a no-op; MetadataEnricherOrder logs a WARN for this.
+		assert.Empty(t, cfg.MetadataEnricherOrder())
+	})
+}
+
+// Governing: ADR-0009 (Viper configuration), ADR-0023 (multi-database support), SPEC key-rotation
+// LoadDatabase must work standalone — with ONLY database env vars set — so
+// `spotter-admin rotate-key` does not require full server configuration.
+func TestLoadDatabase(t *testing.T) {
+	// clearServerEnv blanks all full-server required vars to prove LoadDatabase
+	// does not need them (and to shield against values leaking from the shell).
+	clearServerEnv := func(t *testing.T) {
+		t.Helper()
+		t.Setenv("SPOTTER_NAVIDROME_BASE_URL", "")
+		t.Setenv("SPOTTER_OPENAI_API_KEY", "")
+		t.Setenv("SPOTTER_SECURITY_ENCRYPTION_KEY", "")
+		t.Setenv("SPOTTER_SECURITY_JWT_SECRET", "")
+		t.Setenv("SPOTTER_LIDARR_BASE_URL", "")
+		t.Setenv("SPOTTER_LIDARR_API_KEY", "")
+	}
+
+	t.Run("standalone with no server config", func(t *testing.T) {
+		clearServerEnv(t)
+		t.Setenv("SPOTTER_DATABASE_DRIVER", "sqlite3")
+		t.Setenv("SPOTTER_DATABASE_SOURCE", "file:rotate.db?_fk=1")
+
+		// Full Load must fail without server config...
+		_, err := Load()
+		require.Error(t, err)
+
+		// ...but LoadDatabase succeeds with database vars alone.
+		cfg, err := LoadDatabase()
+		require.NoError(t, err)
+		assert.Equal(t, "sqlite3", cfg.Database.Driver)
+		assert.Equal(t, "file:rotate.db?_fk=1", cfg.Database.Source)
+	})
+
+	t.Run("defaults when nothing set", func(t *testing.T) {
+		clearServerEnv(t)
+		t.Setenv("SPOTTER_DATABASE_DRIVER", "")
+		t.Setenv("SPOTTER_DATABASE_SOURCE", "")
+
+		cfg, err := LoadDatabase()
+		require.NoError(t, err)
+		assert.Equal(t, "sqlite3", cfg.Database.Driver)
+		assert.Equal(t, "file:spotter.db?cache=shared&_fk=1", cfg.Database.Source)
+	})
+
+	t.Run("driver-specific default source", func(t *testing.T) {
+		clearServerEnv(t)
+		t.Setenv("SPOTTER_DATABASE_DRIVER", "postgres")
+		t.Setenv("SPOTTER_DATABASE_SOURCE", "")
+
+		cfg, err := LoadDatabase()
+		require.NoError(t, err)
+		assert.Equal(t, "host=localhost port=5432 dbname=spotter sslmode=disable", cfg.Database.Source)
+	})
+
+	t.Run("invalid driver rejected", func(t *testing.T) {
+		clearServerEnv(t)
+		t.Setenv("SPOTTER_DATABASE_DRIVER", "cockroachdb")
+
+		_, err := LoadDatabase()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported database driver")
+	})
 }
 
 // Governing: ADR-0009 (Viper configuration), SPEC graceful-shutdown REQ-TMO-005
@@ -383,6 +456,24 @@ func TestShutdownTimeout(t *testing.T) {
 	t.Run("invalid falls back to default", func(t *testing.T) {
 		setRequiredEnvVars(t)
 		t.Setenv("SPOTTER_SHUTDOWN_TIMEOUT", "not-a-duration")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		assert.Equal(t, 30*time.Second, cfg.GetShutdownTimeout())
+	})
+
+	t.Run("negative falls back to default", func(t *testing.T) {
+		setRequiredEnvVars(t)
+		t.Setenv("SPOTTER_SHUTDOWN_TIMEOUT", "-5s")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		assert.Equal(t, 30*time.Second, cfg.GetShutdownTimeout())
+	})
+
+	t.Run("zero falls back to default", func(t *testing.T) {
+		setRequiredEnvVars(t)
+		t.Setenv("SPOTTER_SHUTDOWN_TIMEOUT", "0s")
 
 		cfg, err := Load()
 		require.NoError(t, err)
@@ -418,6 +509,26 @@ func TestMaxConcurrentJobs(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 10, cfg.GetMaxConcurrentJobs())
 	})
+
+	t.Run("negative falls back to default", func(t *testing.T) {
+		setRequiredEnvVars(t)
+		t.Setenv("SPOTTER_MAX_CONCURRENT_JOBS", "-3")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		assert.Equal(t, 10, cfg.GetMaxConcurrentJobs())
+	})
+
+	// Governing: ADR-0009 (fail fast with clear error messages)
+	t.Run("non-numeric returns clear validation error", func(t *testing.T) {
+		setRequiredEnvVars(t)
+		t.Setenv("SPOTTER_MAX_CONCURRENT_JOBS", "lots")
+
+		_, err := Load()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "max_concurrent_jobs must be an integer")
+		assert.Contains(t, err.Error(), `"lots"`)
+	})
 }
 
 // Governing: ADR-0026, SPEC-0015 (public base URL used in sync-failure email links)
@@ -434,6 +545,15 @@ func TestServerBaseURL(t *testing.T) {
 	t.Run("env override", func(t *testing.T) {
 		setRequiredEnvVars(t)
 		t.Setenv("SPOTTER_SERVER_BASE_URL", "https://spotter.example.com")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		assert.Equal(t, "https://spotter.example.com", cfg.Server.BaseURL)
+	})
+
+	t.Run("trailing slashes are trimmed", func(t *testing.T) {
+		setRequiredEnvVars(t)
+		t.Setenv("SPOTTER_SERVER_BASE_URL", "https://spotter.example.com//")
 
 		cfg, err := Load()
 		require.NoError(t, err)
@@ -465,6 +585,15 @@ func TestSyncHistoryLookback(t *testing.T) {
 	t.Run("invalid falls back to default", func(t *testing.T) {
 		setRequiredEnvVars(t)
 		t.Setenv("SPOTTER_SYNC_HISTORY_LOOKBACK", "one-fortnight")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		assert.Equal(t, 720*time.Hour, cfg.GetSyncHistoryLookback())
+	})
+
+	t.Run("negative falls back to default", func(t *testing.T) {
+		setRequiredEnvVars(t)
+		t.Setenv("SPOTTER_SYNC_HISTORY_LOOKBACK", "-240h")
 
 		cfg, err := Load()
 		require.NoError(t, err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -269,14 +270,206 @@ func TestAIPromptsDirectoryCustom(t *testing.T) {
 }
 
 // setRequiredEnvVars sets all required environment variables for config loading.
+// Lidarr is intentionally absent: it is optional (see TestLidarrOptional).
 func setRequiredEnvVars(t *testing.T) {
 	t.Helper()
 	t.Setenv("SPOTTER_NAVIDROME_BASE_URL", "http://localhost:4533")
 	t.Setenv("SPOTTER_OPENAI_API_KEY", "sk-test-key")
-	t.Setenv("SPOTTER_LIDARR_BASE_URL", "http://localhost:8686")
-	t.Setenv("SPOTTER_LIDARR_API_KEY", "test-api-key")
 	t.Setenv("SPOTTER_SECURITY_ENCRYPTION_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
 	t.Setenv("SPOTTER_SECURITY_JWT_SECRET", "test-jwt-secret-at-least-32-chars")
+	// Explicitly clear optional Lidarr vars so values from the developer's shell
+	// don't leak into tests.
+	t.Setenv("SPOTTER_LIDARR_BASE_URL", "")
+	t.Setenv("SPOTTER_LIDARR_API_KEY", "")
+}
+
+// Governing: ADR-0009 (Viper configuration), SPEC-0014 (compose scenarios MUST start without Lidarr)
+// Lidarr configuration is optional: Load() must succeed with no Lidarr env vars set.
+func TestLidarrOptional(t *testing.T) {
+	setRequiredEnvVars(t)
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.False(t, cfg.IsLidarrEnabled())
+}
+
+// Governing: SPEC-0017 REQ "Background Submitter Goroutine" (submitter only starts if Lidarr is configured)
+func TestLidarrEnabledWhenFullyConfigured(t *testing.T) {
+	setRequiredEnvVars(t)
+	t.Setenv("SPOTTER_LIDARR_BASE_URL", "http://localhost:8686")
+	t.Setenv("SPOTTER_LIDARR_API_KEY", "test-api-key")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.True(t, cfg.IsLidarrEnabled())
+	assert.Equal(t, "http://localhost:8686", cfg.Lidarr.BaseURL)
+	assert.Equal(t, "test-api-key", cfg.Lidarr.APIKey)
+}
+
+// Governing: ADR-0009 (fail fast with clear error messages)
+// Setting only one of the two Lidarr values is a misconfiguration and must fail.
+func TestLidarrPartialConfigRejected(t *testing.T) {
+	t.Run("base_url without api_key", func(t *testing.T) {
+		setRequiredEnvVars(t)
+		t.Setenv("SPOTTER_LIDARR_BASE_URL", "http://localhost:8686")
+
+		_, err := Load()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "lidarr.base_url and lidarr.api_key must both be set")
+	})
+
+	t.Run("api_key without base_url", func(t *testing.T) {
+		setRequiredEnvVars(t)
+		t.Setenv("SPOTTER_LIDARR_API_KEY", "test-api-key")
+
+		_, err := Load()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "lidarr.base_url and lidarr.api_key must both be set")
+	})
+}
+
+// Governing: ADR-0015 (pluggable enricher registry), ADR-0009 (Lidarr optional)
+// The lidarr enricher is filtered out of the enricher order when Lidarr is unconfigured.
+func TestMetadataEnricherOrderExcludesLidarrWhenUnconfigured(t *testing.T) {
+	t.Run("default order", func(t *testing.T) {
+		setRequiredEnvVars(t)
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		assert.NotContains(t, cfg.MetadataEnricherOrder(), "lidarr")
+	})
+
+	t.Run("explicit order", func(t *testing.T) {
+		setRequiredEnvVars(t)
+		t.Setenv("SPOTTER_METADATA_ORDER", "lidarr,musicbrainz,openai")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		assert.Equal(t, []string{"musicbrainz", "openai"}, cfg.MetadataEnricherOrder())
+	})
+
+	t.Run("included when lidarr configured", func(t *testing.T) {
+		setRequiredEnvVars(t)
+		t.Setenv("SPOTTER_LIDARR_BASE_URL", "http://localhost:8686")
+		t.Setenv("SPOTTER_LIDARR_API_KEY", "test-api-key")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		assert.Contains(t, cfg.MetadataEnricherOrder(), "lidarr")
+	})
+}
+
+// Governing: ADR-0009 (Viper configuration), SPEC graceful-shutdown REQ-TMO-005
+// SPOTTER_SHUTDOWN_TIMEOUT must bind through Viper (moved out of raw os.Getenv).
+func TestShutdownTimeout(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		setRequiredEnvVars(t)
+		t.Setenv("SPOTTER_SHUTDOWN_TIMEOUT", "")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		assert.Equal(t, 30*time.Second, cfg.GetShutdownTimeout())
+	})
+
+	t.Run("env override", func(t *testing.T) {
+		setRequiredEnvVars(t)
+		t.Setenv("SPOTTER_SHUTDOWN_TIMEOUT", "45s")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		assert.Equal(t, 45*time.Second, cfg.GetShutdownTimeout())
+	})
+
+	t.Run("invalid falls back to default", func(t *testing.T) {
+		setRequiredEnvVars(t)
+		t.Setenv("SPOTTER_SHUTDOWN_TIMEOUT", "not-a-duration")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		assert.Equal(t, 30*time.Second, cfg.GetShutdownTimeout())
+	})
+}
+
+// Governing: ADR-0009 (Viper configuration), SPEC graceful-shutdown REQ-SEM-002
+// SPOTTER_MAX_CONCURRENT_JOBS must bind through Viper (moved out of raw os.Getenv).
+func TestMaxConcurrentJobs(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		setRequiredEnvVars(t)
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		assert.Equal(t, 10, cfg.GetMaxConcurrentJobs())
+	})
+
+	t.Run("env override", func(t *testing.T) {
+		setRequiredEnvVars(t)
+		t.Setenv("SPOTTER_MAX_CONCURRENT_JOBS", "5")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		assert.Equal(t, 5, cfg.GetMaxConcurrentJobs())
+	})
+
+	t.Run("non-positive falls back to default", func(t *testing.T) {
+		setRequiredEnvVars(t)
+		t.Setenv("SPOTTER_MAX_CONCURRENT_JOBS", "0")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		assert.Equal(t, 10, cfg.GetMaxConcurrentJobs())
+	})
+}
+
+// Governing: ADR-0026, SPEC-0015 (public base URL used in sync-failure email links)
+func TestServerBaseURL(t *testing.T) {
+	t.Run("default empty", func(t *testing.T) {
+		setRequiredEnvVars(t)
+		t.Setenv("SPOTTER_SERVER_BASE_URL", "")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		assert.Equal(t, "", cfg.Server.BaseURL)
+	})
+
+	t.Run("env override", func(t *testing.T) {
+		setRequiredEnvVars(t)
+		t.Setenv("SPOTTER_SERVER_BASE_URL", "https://spotter.example.com")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		assert.Equal(t, "https://spotter.example.com", cfg.Server.BaseURL)
+	})
+}
+
+// Governing: SPEC listen-playlist-sync REQ-SYNC-020 (configurable initial history lookback)
+func TestSyncHistoryLookback(t *testing.T) {
+	t.Run("default 720h", func(t *testing.T) {
+		setRequiredEnvVars(t)
+		t.Setenv("SPOTTER_SYNC_HISTORY_LOOKBACK", "")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		assert.Equal(t, 720*time.Hour, cfg.GetSyncHistoryLookback())
+	})
+
+	t.Run("env override", func(t *testing.T) {
+		setRequiredEnvVars(t)
+		t.Setenv("SPOTTER_SYNC_HISTORY_LOOKBACK", "240h")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		assert.Equal(t, "240h", cfg.Sync.HistoryLookback)
+		assert.Equal(t, 240*time.Hour, cfg.GetSyncHistoryLookback())
+	})
+
+	t.Run("invalid falls back to default", func(t *testing.T) {
+		setRequiredEnvVars(t)
+		t.Setenv("SPOTTER_SYNC_HISTORY_LOOKBACK", "one-fortnight")
+
+		cfg, err := Load()
+		require.NoError(t, err)
+		assert.Equal(t, 720*time.Hour, cfg.GetSyncHistoryLookback())
+	})
 }
 
 // Governing: SPEC-0014 REQ "Test Coverage" (valid drivers, invalid driver rejection, default source per driver)

--- a/internal/services/sync.go
+++ b/internal/services/sync.go
@@ -266,9 +266,11 @@ func (s *Syncer) syncHistory(ctx context.Context, u *ent.User, activeProviders [
 			since = lastListen.PlayedAt
 			s.logger.Debug("found last listen", "provider", provider.Type(), "played_at", since)
 		} else {
-			// Default to beginning of time if no history exists to fetch everything
-			since = time.Unix(0, 0)
-			s.logger.Debug("no previous history found, defaulting lookback to beginning of time", "provider", provider.Type(), "since", since)
+			// Governing: SPEC listen-playlist-sync REQ-SYNC-020 (configurable initial history lookback), ADR-0009
+			// No history exists: use the configured lookback window (sync.history_lookback, default 720h/30d)
+			lookback := s.config.GetSyncHistoryLookback()
+			since = time.Now().Add(-lookback)
+			s.logger.Debug("no previous history found, using configured lookback", "provider", provider.Type(), "lookback", lookback, "since", since)
 		}
 
 		s.logger.Debug("fetching history", "provider", provider.Type(), "since", since)


### PR DESCRIPTION
## What / Why

Implements story #324 (part of epic #323, foundation story). ADR-0009's confirmation clause — no direct `os.Getenv()` for application configuration outside `config.Load()` — was violated in both binaries, and config validation made Lidarr accidentally mandatory, so the shipped docker-compose examples could not start and SPEC-0017's "submitter SHALL only start if Lidarr is configured" branch was dead code.

### Changes

- **Shutdown/concurrency keys moved into config** (`internal/config/config.go`, `cmd/server/main.go`): `SPOTTER_SHUTDOWN_TIMEOUT` → `shutdown_timeout` (default `30s`), `SPOTTER_MAX_CONCURRENT_JOBS` → `max_concurrent_jobs` (default `10`). New `GetShutdownTimeout()` / `GetMaxConcurrentJobs()` helpers preserve the old fallback-on-invalid behavior. Env var names are unchanged (Viper key replacer maps them 1:1). Governing: ADR-0009, SPEC graceful-shutdown REQ-TMO-005 / REQ-SEM-002.
- **`cmd/admin` uses `config.Load()`** for database driver/DSN instead of hand-rolled `os.Getenv` + duplicated SQLite defaults; `--db` flag still overrides. Diff kept surgical to the `main()` config-loading region (key-rotation logic untouched for #335). Governing: ADR-0023, ADR-0009.
- **Lidarr is optional**: validation no longer hard-fails on unset `lidarr.base_url`/`lidarr.api_key` — it only rejects *partial* configuration (one set without the other). New `Config.IsLidarrEnabled()` gates the Lidarr enricher registration and the background submitter in `cmd/server/main.go`, and `MetadataEnricherOrder()` filters `lidarr` out when unconfigured (avoids per-run "unknown enricher type" warnings without touching `internal/services/metadata.go`, owned by #343). Governing: SPEC-0014 compose scenarios, SPEC-0017 REQ "Background Submitter Goroutine".
- **New `server.base_url` key** (default empty) for sync-failure email links; consumed by the email-content story in #323. Governing: ADR-0026, SPEC-0015.
- **New `sync.history_lookback` key** (default `720h`) wired into `internal/services/sync.go` — first-time history fetch now looks back 30 days instead of syncing from the Unix epoch. Governing: SPEC listen-playlist-sync REQ-SYNC-020.
- **Docs**: `.env.example` and `docs-site/docs/getting-started/configuration.md` updated for all new/moved keys, including the Lidarr both-or-neither rule.

## Test Evidence

- `make test` passes: 27 packages ok, 0 failures (includes codegen).
- New config tests (all passing): `TestLidarrOptional`, `TestLidarrEnabledWhenFullyConfigured`, `TestLidarrPartialConfigRejected`, `TestShutdownTimeout` (default/override/invalid), `TestMaxConcurrentJobs` (default/override/non-positive), `TestServerBaseURL`, `TestSyncHistoryLookback` (default/override/invalid), `TestMetadataEnricherOrderExcludesLidarrWhenUnconfigured` — proving `SPOTTER_*` env vars still bind through Viper.
- Acceptance grep: `grep -rn "os.Getenv" cmd/ internal/ --include='*.go'` returns only comments — zero application-config reads outside `internal/config`.
- `gofmt -l cmd internal` is empty; `go vet` clean.
- Startup smoke tests (no Lidarr env vars):
  - postgres driver pointing at a closed port: config validation passes and the process reaches DB connection (`failed to connect to database ... connection refused`) — the SPEC-0014 compose "MUST start" gate.
  - sqlite full startup: logs `lidarr enricher disabled (lidarr not configured)` and `lidarr queue submitter disabled (lidarr not configured)`, then `starting server`.

## Notes for Reviewers

- `cmd/admin rotate-key` now requires the full server config env (Navidrome URL, OpenAI key, encryption key, JWT secret) since `config.Load()` validates required fields. In deployed environments the admin tool runs with the server's env so this holds; flagging in case a standalone-DSN-only usage matters.
- Partial Lidarr config (one of the two vars) is now an explicit startup error rather than silently required — deliberate fail-fast per ADR-0009.

Closes #324

Part of epic #323. Governing artifacts: ADR-0009 (Viper configuration), ADR-0023, ADR-0026, ADR-0015, SPEC-0014 (multi-database-support), SPEC-0015 (sync-failure-email-notifications), SPEC-0017 REQ "Background Submitter Goroutine", SPEC graceful-shutdown REQ-TMO-005 / REQ-SEM-002, SPEC listen-playlist-sync REQ-SYNC-020.

🤖 Posted on behalf of `@joestump` by [Claude](https://claude.ai).