### PR TITLE
Replace IsEncrypted heuristic with explicit enc:v1: ciphertext marker (fixes auth-row bricking)

### DIFF
--- a/cmd/admin/main.go
+++ b/cmd/admin/main.go
@@ -17,7 +17,17 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 )
 
-const driverSQLite3 = "sqlite3"
+// Database driver names (ADR-0023 multi-database support). Kept in sync with
+// the drivers accepted by internal/config validation.
+const (
+	driverSQLite3  = "sqlite3"
+	driverPostgres = "postgres"
+	driverMySQL    = "mysql"
+)
+
+// selectEncryptedFieldSQL is the Sprintf format used to read encrypted
+// columns: args are the column list and the table name.
+const selectEncryptedFieldSQL = "SELECT id, %s FROM %s"
 
 // encryptedField describes a single encrypted column in the database.
 type encryptedField struct {
@@ -258,7 +268,7 @@ const (
 // Governing: ADR-0021, SPEC key-rotation REQ "ROT-005"
 func acquireRotationGuard(db *sql.DB, driver string) error {
 	switch driver {
-	case "postgres":
+	case driverPostgres:
 		var locked bool
 		if err := db.QueryRow("SELECT pg_try_advisory_lock($1)", rotationLockID).Scan(&locked); err != nil {
 			return fmt.Errorf("failed to acquire rotation advisory lock: %w", err)
@@ -273,7 +283,7 @@ func acquireRotationGuard(db *sql.DB, driver string) error {
 		if others > 0 {
 			return fmt.Errorf("%d other session(s) connected to the database (is the server running?); stop the server before rotating", others)
 		}
-	case "mysql":
+	case driverMySQL:
 		var locked sql.NullInt64
 		if err := db.QueryRow("SELECT GET_LOCK(?, 0)", rotationLockName).Scan(&locked); err != nil {
 			return fmt.Errorf("failed to acquire rotation advisory lock: %w", err)
@@ -311,7 +321,7 @@ func acquireRotationGuard(db *sql.DB, driver string) error {
 // Governing: SPEC key-rotation REQ "ROT-004", ADR-0006, ADR-0021
 func verifyOldKey(db *sql.DB, oldEnc *crypto.Encryptor) (found, verified bool, err error) {
 	for _, f := range allEncryptedFields {
-		query := fmt.Sprintf("SELECT id, %s FROM %s", f.column, f.table)
+		query := fmt.Sprintf(selectEncryptedFieldSQL, f.column, f.table)
 		rows, err := db.Query(query)
 		if err != nil {
 			return false, false, fmt.Errorf("failed to query %s.%s: %w", f.table, f.column, err)
@@ -409,7 +419,7 @@ func reencryptAll(tx *sql.Tx, oldEnc, newEnc *crypto.Encryptor, driver string) (
 
 	for _, tf := range grouped {
 		cols := strings.Join(tf.columns, ", ")
-		query := fmt.Sprintf("SELECT id, %s FROM %s", cols, tf.table)
+		query := fmt.Sprintf(selectEncryptedFieldSQL, cols, tf.table)
 		rows, err := tx.Query(query)
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to query %s: %w", tf.table, err)
@@ -466,7 +476,7 @@ func reencryptAll(tx *sql.Tx, oldEnc, newEnc *crypto.Encryptor, driver string) (
 				}
 
 				var updateSQL string
-				if driver == "postgres" {
+				if driver == driverPostgres {
 					updateSQL = fmt.Sprintf("UPDATE %s SET %s = $1 WHERE id = $2", tf.table, col)
 				} else {
 					updateSQL = fmt.Sprintf("UPDATE %s SET %s = ? WHERE id = ?", tf.table, col)
@@ -492,7 +502,7 @@ func reencryptAll(tx *sql.Tx, oldEnc, newEnc *crypto.Encryptor, driver string) (
 // Governing: SPEC key-rotation REQ "ROT-020", REQ "ROT-021"
 func verifyNewKey(db *sql.DB, newEnc *crypto.Encryptor) error {
 	for _, f := range allEncryptedFields {
-		query := fmt.Sprintf("SELECT id, %s FROM %s", f.column, f.table)
+		query := fmt.Sprintf(selectEncryptedFieldSQL, f.column, f.table)
 		rows, err := db.Query(query)
 		if err != nil {
 			return fmt.Errorf("verification query failed for %s.%s: %w", f.table, f.column, err)

--- a/cmd/admin/main.go
+++ b/cmd/admin/main.go
@@ -115,6 +115,11 @@ func run(oldKeyHex, newKeyHex, driver, dbDSN string) error {
 	}
 	defer func() { _ = db.Close() }()
 
+	// Pin the pool to a single connection so session-scoped state (the SQLite
+	// exclusive-lock probe, the postgres/mysql advisory locks below) is held
+	// on the same connection every statement runs on.
+	db.SetMaxOpenConns(1)
+
 	if driver == driverSQLite3 {
 		// SQLite-specific: attempt to acquire an exclusive lock to check if the server is running.
 		if _, err := db.Exec("PRAGMA locking_mode=EXCLUSIVE"); err != nil {
@@ -130,6 +135,17 @@ func run(oldKeyHex, newKeyHex, driver, dbDSN string) error {
 		// PostgreSQL/MySQL: verify connectivity with a ping.
 		if err := db.Ping(); err != nil {
 			return fmt.Errorf("failed to connect to database: %w", err)
+		}
+		// Governing: ADR-0021 — "server not running" pre-rotation guard.
+		// Client-server databases have no equivalent of the SQLite BEGIN
+		// EXCLUSIVE probe, so we (a) take a session-scoped advisory lock to
+		// serialize rotations, and (b) refuse to run while any other session
+		// is connected to this database — the strongest available signal
+		// that the Spotter server is still running. Note the connection
+		// check is advisory: a server that connects lazily could slip past
+		// it, so operators MUST still stop the server before rotating.
+		if err := acquireRotationGuard(db, driver); err != nil {
+			return err
 		}
 	}
 
@@ -202,43 +218,151 @@ func parseHexKey(hexKey string) ([]byte, error) {
 	return key, nil
 }
 
-// verifyOldKey attempts to decrypt one encrypted field with the old key.
-// Returns (true, nil) if at least one field was found and decrypted successfully.
-// Returns (false, nil) if no encrypted fields exist at all.
-// Governing: SPEC key-rotation REQ "ROT-004"
+// rotationLockID and rotationLockName identify the cross-process advisory
+// lock that serializes key rotations on client-server databases.
+const (
+	rotationLockID   = int64(0x53504f54524f5431) // ASCII "SPOTROT1"
+	rotationLockName = "spotter_key_rotation"
+)
+
+// acquireRotationGuard is the "server not running" pre-rotation check for
+// client-server databases: it takes a session-scoped advisory lock (so two
+// rotations cannot run concurrently) and refuses to proceed while any other
+// session is connected to this database. The lock lives on the pool's single
+// pinned connection (SetMaxOpenConns(1)) and is released automatically when
+// the process exits. The other-sessions check is best-effort — a server that
+// opens connections lazily could pass it — so stopping the server before
+// rotation remains mandatory (ADR-0021).
+// Governing: ADR-0021, SPEC key-rotation REQ "ROT-005"
+func acquireRotationGuard(db *sql.DB, driver string) error {
+	switch driver {
+	case "postgres":
+		var locked bool
+		if err := db.QueryRow("SELECT pg_try_advisory_lock($1)", rotationLockID).Scan(&locked); err != nil {
+			return fmt.Errorf("failed to acquire rotation advisory lock: %w", err)
+		}
+		if !locked {
+			return fmt.Errorf("another key rotation is already in progress (advisory lock %d is held)", rotationLockID)
+		}
+		var others int
+		if err := db.QueryRow("SELECT count(*) FROM pg_stat_activity WHERE datname = current_database() AND pid <> pg_backend_pid()").Scan(&others); err != nil {
+			return fmt.Errorf("failed to check for other database sessions: %w", err)
+		}
+		if others > 0 {
+			return fmt.Errorf("%d other session(s) connected to the database (is the server running?); stop the server before rotating", others)
+		}
+	case "mysql":
+		var locked sql.NullInt64
+		if err := db.QueryRow("SELECT GET_LOCK(?, 0)", rotationLockName).Scan(&locked); err != nil {
+			return fmt.Errorf("failed to acquire rotation advisory lock: %w", err)
+		}
+		if !locked.Valid || locked.Int64 != 1 {
+			return fmt.Errorf("another key rotation is already in progress (lock %q is held)", rotationLockName)
+		}
+		var others int
+		if err := db.QueryRow("SELECT COUNT(*) FROM information_schema.processlist WHERE id <> CONNECTION_ID() AND db = DATABASE()").Scan(&others); err != nil {
+			return fmt.Errorf("failed to check for other database sessions: %w", err)
+		}
+		if others > 0 {
+			return fmt.Errorf("%d other session(s) connected to the database (is the server running?); stop the server before rotating", others)
+		}
+	}
+	return nil
+}
+
+// verifyOldKey scans encrypted fields for evidence that the old key is
+// correct before any data is modified. Values are classified by format
+// (ADR-0006):
+//   - marked ciphertext (enc:v1:) MUST decrypt with the old key — a failure
+//     is definitive proof of a wrong key (or corruption) and aborts rotation
+//   - legacy-shaped values (bare base64) are attempted; success verifies the
+//     old key, failure is ambiguous (may be plaintext that merely looks like
+//     ciphertext — issue #335) and does not abort
+//   - anything else is plaintext from before encryption was enabled
+//
+// Returns (false, nil) when no non-empty values exist (nothing to rotate).
+// When values exist but none positively verified the old key, rotation
+// proceeds with a warning: unverifiable values are treated as plaintext and
+// encrypted with the new key.
+// Governing: SPEC key-rotation REQ "ROT-004", ADR-0006, ADR-0021
 func verifyOldKey(db *sql.DB, oldEnc *crypto.Encryptor) (bool, error) {
+	foundValue := false
 	for _, f := range allEncryptedFields {
-		query := fmt.Sprintf("SELECT id, %s FROM %s LIMIT 1", f.column, f.table)
+		query := fmt.Sprintf("SELECT id, %s FROM %s", f.column, f.table)
 		rows, err := db.Query(query)
 		if err != nil {
 			return false, fmt.Errorf("failed to query %s.%s: %w", f.table, f.column, err)
 		}
 
-		if rows.Next() {
+		for rows.Next() {
 			var id int
 			var val sql.NullString
 			if err := rows.Scan(&id, &val); err != nil {
 				_ = rows.Close()
 				return false, fmt.Errorf("failed to scan %s.%s: %w", f.table, f.column, err)
 			}
-			_ = rows.Close()
+			if !val.Valid || val.String == "" {
+				continue
+			}
+			foundValue = true
 
-			if val.Valid && val.String != "" {
-				_, err := oldEnc.Decrypt(val.String)
-				if err != nil {
+			if crypto.IsEncrypted(val.String) {
+				if _, err := oldEnc.Decrypt(val.String); err != nil {
+					_ = rows.Close()
 					return false, fmt.Errorf("old key cannot decrypt %s.%s (row id=%d): %w", f.table, f.column, id, err)
 				}
+				_ = rows.Close()
 				return true, nil
 			}
-		} else {
+			if crypto.LooksLikeLegacyCiphertext(val.String) {
+				if _, err := oldEnc.Decrypt(val.String); err == nil {
+					_ = rows.Close()
+					return true, nil
+				}
+			}
+		}
+		if err := rows.Err(); err != nil {
 			_ = rows.Close()
+			return false, fmt.Errorf("error iterating %s.%s: %w", f.table, f.column, err)
+		}
+		_ = rows.Close()
+	}
+
+	if foundValue {
+		fmt.Fprintln(os.Stderr, "Warning: no stored value positively verified the old key; values not decryptable with it will be treated as plaintext and encrypted with the new key.")
+	}
+	return foundValue, nil
+}
+
+// resolveStoredValue recovers the plaintext behind a stored credential value
+// during rotation. Marked ciphertext MUST decrypt with the old key;
+// legacy-shaped values fall back to being treated as plaintext on GCM
+// failure (self-heal, issue #335); anything else is plaintext from before
+// encryption was enabled. Every value is subsequently re-encrypted with the
+// new key, so rotation also migrates legacy ciphertext and plaintext rows to
+// the marked format.
+// Governing: ADR-0006, ADR-0021
+func resolveStoredValue(oldEnc *crypto.Encryptor, stored string) (plaintext string, treatedAsPlaintext bool, err error) {
+	if crypto.IsEncrypted(stored) {
+		decrypted, err := oldEnc.Decrypt(stored)
+		if err != nil {
+			return "", false, err
+		}
+		return decrypted, false, nil
+	}
+	if crypto.LooksLikeLegacyCiphertext(stored) {
+		if decrypted, err := oldEnc.Decrypt(stored); err == nil {
+			return decrypted, false, nil
 		}
 	}
-	return false, nil
+	return stored, true, nil
 }
 
 // reencryptAll re-encrypts all encrypted fields in a single transaction.
-// Returns per-table row counts and total field count.
+// It handles all three stored formats (marked ciphertext, legacy unmarked
+// ciphertext, plaintext) via resolveStoredValue and always writes back the
+// marked format under the new key, so a rotated database is uniformly
+// enc:v1:-marked. Returns per-table row counts and total field count.
 // Governing: SPEC key-rotation REQ "ROT-010", REQ "ROT-011", REQ "ROT-012", REQ "ROT-013", ADR-0023 (multi-database support)
 func reencryptAll(tx *sql.Tx, oldEnc, newEnc *crypto.Encryptor, driver string) (map[string]int, int, error) {
 	counts := make(map[string]int)
@@ -287,14 +411,17 @@ func reencryptAll(tx *sql.Tx, oldEnc, newEnc *crypto.Encryptor, driver string) (
 					continue // REQ "ROT-012": skip null/empty
 				}
 
-				// REQ "ROT-040": Decrypt with old key
-				plaintext, err := oldEnc.Decrypt(vals[i].String)
+				// REQ "ROT-040": Recover plaintext (marked, legacy, or plaintext value)
+				plaintext, treatedAsPlaintext, err := resolveStoredValue(oldEnc, vals[i].String)
 				if err != nil {
 					_ = rows.Close()
 					return nil, 0, fmt.Errorf("decryption failed for %s.%s (row id=%d): %w", tf.table, col, id, err)
 				}
+				if treatedAsPlaintext {
+					fmt.Fprintf(os.Stderr, "Warning: %s.%s (row id=%d) is not decryptable with the old key; treating as plaintext and encrypting with the new key\n", tf.table, col, id)
+				}
 
-				// REQ "ROT-041": Encrypt with new key
+				// REQ "ROT-041": Encrypt with new key (always marked format)
 				newCipher, err := newEnc.Encrypt(plaintext)
 				if err != nil {
 					_ = rows.Close()

--- a/cmd/admin/main.go
+++ b/cmd/admin/main.go
@@ -36,7 +36,7 @@ var allEncryptedFields = []encryptedField{
 
 func main() {
 	if len(os.Args) < 2 || os.Args[1] != "rotate-key" {
-		fmt.Fprintln(os.Stderr, "Usage: spotter-admin rotate-key --old-key=<hex> --new-key=<hex> [--db=<dsn>]")
+		fmt.Fprintln(os.Stderr, "Usage: spotter-admin rotate-key --old-key=<hex> --new-key=<hex> [--db=<dsn>] [--force]")
 		os.Exit(1)
 	}
 
@@ -45,6 +45,7 @@ func main() {
 	oldKeyHex := fs.String("old-key", "", "Current 64-char hex encryption key (required)")
 	newKeyHex := fs.String("new-key", "", "New 64-char hex encryption key (required)")
 	dbDSNFlag := fs.String("db", "", "Database DSN (overrides SPOTTER_DATABASE_SOURCE env var)")
+	force := fs.Bool("force", false, "Proceed even when no stored value verifies the old key (DANGEROUS: with a wrong old key this irrecoverably corrupts all credentials; only use when the stored values really are plaintext)")
 	if err := fs.Parse(os.Args[2:]); err != nil {
 		os.Exit(1)
 	}
@@ -67,13 +68,13 @@ func main() {
 		dsn = *dbDSNFlag
 	}
 
-	if err := run(*oldKeyHex, *newKeyHex, driver, dsn); err != nil {
+	if err := run(*oldKeyHex, *newKeyHex, driver, dsn, *force); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-func run(oldKeyHex, newKeyHex, driver, dbDSN string) error {
+func run(oldKeyHex, newKeyHex, driver, dbDSN string, force bool) error {
 	// --- REQ "ROT-001": Validate required flags ---
 	if oldKeyHex == "" {
 		return fmt.Errorf("--old-key is required")
@@ -150,13 +151,25 @@ func run(oldKeyHex, newKeyHex, driver, dbDSN string) error {
 	}
 
 	// --- REQ "ROT-004": Pre-rotation validation ---
-	found, err := verifyOldKey(db, oldEnc)
+	found, verified, err := verifyOldKey(db, oldEnc)
 	if err != nil {
 		return fmt.Errorf("pre-rotation validation failed: %w", err)
 	}
 	if !found {
 		fmt.Println("Warning: no encrypted fields found in the database. Nothing to rotate.")
 		return nil
+	}
+	if !verified {
+		// No stored value positively proved the old key is correct. On an
+		// all-legacy (pre-marker) database this is exactly what a WRONG old
+		// key looks like: proceeding would wrap garbage under the new key
+		// and report success, corrupting every credential. Hard-abort unless
+		// the operator explicitly forces it (e.g. a pre-encryption database
+		// whose values really are plaintext).
+		if !force {
+			return fmt.Errorf("no stored value could be decrypted with --old-key; refusing to rotate because a wrong old key would irrecoverably corrupt all credentials. If the stored values really are unencrypted plaintext, re-run with --force")
+		}
+		fmt.Fprintln(os.Stderr, "Warning: --force given; values not decryptable with the old key will be treated as plaintext and encrypted with the new key.")
 	}
 
 	// --- REQ "ROT-010": All re-encryption in one transaction ---
@@ -230,9 +243,18 @@ const (
 // rotations cannot run concurrently) and refuses to proceed while any other
 // session is connected to this database. The lock lives on the pool's single
 // pinned connection (SetMaxOpenConns(1)) and is released automatically when
-// the process exits. The other-sessions check is best-effort — a server that
-// opens connections lazily could pass it — so stopping the server before
-// rotation remains mandatory (ADR-0021).
+// the process exits.
+//
+// Known caveats — the guard is best-effort, stopping the server before
+// rotation remains mandatory (ADR-0021):
+//   - A server that opens its connections lazily can slip past the
+//     other-sessions check.
+//   - MySQL: information_schema.processlist only shows other users' sessions
+//     when the rotation user has the PROCESS privilege; without it the check
+//     can pass while another user's server session exists.
+//   - If the pinned connection drops and database/sql reconnects, the
+//     advisory lock is silently lost for the remainder of the run.
+//
 // Governing: ADR-0021, SPEC key-rotation REQ "ROT-005"
 func acquireRotationGuard(db *sql.DB, driver string) error {
 	switch driver {
@@ -280,18 +302,19 @@ func acquireRotationGuard(db *sql.DB, driver string) error {
 //     ciphertext — issue #335) and does not abort
 //   - anything else is plaintext from before encryption was enabled
 //
-// Returns (false, nil) when no non-empty values exist (nothing to rotate).
-// When values exist but none positively verified the old key, rotation
-// proceeds with a warning: unverifiable values are treated as plaintext and
-// encrypted with the new key.
+// Returns (found=false, ...) when no non-empty values exist (nothing to
+// rotate), and verified=true only when at least one stored value decrypted
+// with the old key. The caller MUST hard-abort on found && !verified unless
+// the operator explicitly forces the rotation: on an all-legacy database a
+// wrong old key is indistinguishable from all-plaintext data, and rotating
+// with a wrong key would irrecoverably corrupt every credential.
 // Governing: SPEC key-rotation REQ "ROT-004", ADR-0006, ADR-0021
-func verifyOldKey(db *sql.DB, oldEnc *crypto.Encryptor) (bool, error) {
-	foundValue := false
+func verifyOldKey(db *sql.DB, oldEnc *crypto.Encryptor) (found, verified bool, err error) {
 	for _, f := range allEncryptedFields {
 		query := fmt.Sprintf("SELECT id, %s FROM %s", f.column, f.table)
 		rows, err := db.Query(query)
 		if err != nil {
-			return false, fmt.Errorf("failed to query %s.%s: %w", f.table, f.column, err)
+			return false, false, fmt.Errorf("failed to query %s.%s: %w", f.table, f.column, err)
 		}
 
 		for rows.Next() {
@@ -299,39 +322,36 @@ func verifyOldKey(db *sql.DB, oldEnc *crypto.Encryptor) (bool, error) {
 			var val sql.NullString
 			if err := rows.Scan(&id, &val); err != nil {
 				_ = rows.Close()
-				return false, fmt.Errorf("failed to scan %s.%s: %w", f.table, f.column, err)
+				return false, false, fmt.Errorf("failed to scan %s.%s: %w", f.table, f.column, err)
 			}
 			if !val.Valid || val.String == "" {
 				continue
 			}
-			foundValue = true
+			found = true
 
 			if crypto.IsEncrypted(val.String) {
 				if _, err := oldEnc.Decrypt(val.String); err != nil {
 					_ = rows.Close()
-					return false, fmt.Errorf("old key cannot decrypt %s.%s (row id=%d): %w", f.table, f.column, id, err)
+					return true, false, fmt.Errorf("old key cannot decrypt %s.%s (row id=%d): %w", f.table, f.column, id, err)
 				}
 				_ = rows.Close()
-				return true, nil
+				return true, true, nil
 			}
 			if crypto.LooksLikeLegacyCiphertext(val.String) {
 				if _, err := oldEnc.Decrypt(val.String); err == nil {
 					_ = rows.Close()
-					return true, nil
+					return true, true, nil
 				}
 			}
 		}
 		if err := rows.Err(); err != nil {
 			_ = rows.Close()
-			return false, fmt.Errorf("error iterating %s.%s: %w", f.table, f.column, err)
+			return false, false, fmt.Errorf("error iterating %s.%s: %w", f.table, f.column, err)
 		}
 		_ = rows.Close()
 	}
 
-	if foundValue {
-		fmt.Fprintln(os.Stderr, "Warning: no stored value positively verified the old key; values not decryptable with it will be treated as plaintext and encrypted with the new key.")
-	}
-	return foundValue, nil
+	return found, false, nil
 }
 
 // resolveStoredValue recovers the plaintext behind a stored credential value
@@ -381,6 +401,12 @@ func reencryptAll(tx *sql.Tx, oldEnc, newEnc *crypto.Encryptor, driver string) (
 		grouped[f.table].columns = append(grouped[f.table].columns, f.column)
 	}
 
+	// A buffered row of id + column values.
+	type bufferedRow struct {
+		id   int
+		vals []sql.NullString
+	}
+
 	for _, tf := range grouped {
 		cols := strings.Join(tf.columns, ", ")
 		query := fmt.Sprintf("SELECT id, %s FROM %s", cols, tf.table)
@@ -389,7 +415,11 @@ func reencryptAll(tx *sql.Tx, oldEnc, newEnc *crypto.Encryptor, driver string) (
 			return nil, 0, fmt.Errorf("failed to query %s: %w", tf.table, err)
 		}
 
-		rowCount := 0
+		// Buffer all rows before issuing UPDATEs: with the pool pinned to a
+		// single connection, mysql and lib/pq cannot execute tx.Exec while a
+		// tx.Query result set is still open on the same connection (SQLite
+		// tolerates it, the other drivers error at runtime).
+		var buffered []bufferedRow
 		for rows.Next() {
 			// Build scan destinations: id + N columns.
 			scanDest := make([]interface{}, 1+len(tf.columns))
@@ -404,28 +434,35 @@ func reencryptAll(tx *sql.Tx, oldEnc, newEnc *crypto.Encryptor, driver string) (
 				_ = rows.Close()
 				return nil, 0, fmt.Errorf("failed to scan row from %s: %w", tf.table, err)
 			}
+			buffered = append(buffered, bufferedRow{id: id, vals: vals})
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, 0, fmt.Errorf("error iterating %s: %w", tf.table, err)
+		}
+		_ = rows.Close()
 
+		rowCount := 0
+		for _, row := range buffered {
 			rowModified := false
 			for i, col := range tf.columns {
-				if !vals[i].Valid || vals[i].String == "" {
+				if !row.vals[i].Valid || row.vals[i].String == "" {
 					continue // REQ "ROT-012": skip null/empty
 				}
 
 				// REQ "ROT-040": Recover plaintext (marked, legacy, or plaintext value)
-				plaintext, treatedAsPlaintext, err := resolveStoredValue(oldEnc, vals[i].String)
+				plaintext, treatedAsPlaintext, err := resolveStoredValue(oldEnc, row.vals[i].String)
 				if err != nil {
-					_ = rows.Close()
-					return nil, 0, fmt.Errorf("decryption failed for %s.%s (row id=%d): %w", tf.table, col, id, err)
+					return nil, 0, fmt.Errorf("decryption failed for %s.%s (row id=%d): %w", tf.table, col, row.id, err)
 				}
 				if treatedAsPlaintext {
-					fmt.Fprintf(os.Stderr, "Warning: %s.%s (row id=%d) is not decryptable with the old key; treating as plaintext and encrypting with the new key\n", tf.table, col, id)
+					fmt.Fprintf(os.Stderr, "Warning: %s.%s (row id=%d) is not decryptable with the old key; treating as plaintext and encrypting with the new key\n", tf.table, col, row.id)
 				}
 
 				// REQ "ROT-041": Encrypt with new key (always marked format)
 				newCipher, err := newEnc.Encrypt(plaintext)
 				if err != nil {
-					_ = rows.Close()
-					return nil, 0, fmt.Errorf("encryption failed for %s.%s (row id=%d): %w", tf.table, col, id, err)
+					return nil, 0, fmt.Errorf("encryption failed for %s.%s (row id=%d): %w", tf.table, col, row.id, err)
 				}
 
 				var updateSQL string
@@ -434,9 +471,8 @@ func reencryptAll(tx *sql.Tx, oldEnc, newEnc *crypto.Encryptor, driver string) (
 				} else {
 					updateSQL = fmt.Sprintf("UPDATE %s SET %s = ? WHERE id = ?", tf.table, col)
 				}
-				if _, err := tx.Exec(updateSQL, newCipher, id); err != nil {
-					_ = rows.Close()
-					return nil, 0, fmt.Errorf("update failed for %s.%s (row id=%d): %w", tf.table, col, id, err)
+				if _, err := tx.Exec(updateSQL, newCipher, row.id); err != nil {
+					return nil, 0, fmt.Errorf("update failed for %s.%s (row id=%d): %w", tf.table, col, row.id, err)
 				}
 				totalFields++
 				rowModified = true
@@ -445,10 +481,6 @@ func reencryptAll(tx *sql.Tx, oldEnc, newEnc *crypto.Encryptor, driver string) (
 				rowCount++
 			}
 		}
-		if err := rows.Err(); err != nil {
-			return nil, 0, fmt.Errorf("error iterating %s: %w", tf.table, err)
-		}
-		_ = rows.Close()
 		counts[tf.table] = rowCount
 	}
 

--- a/cmd/admin/main_test.go
+++ b/cmd/admin/main_test.go
@@ -121,7 +121,7 @@ func TestParseHexKey(t *testing.T) {
 func TestRunIdenticalKeys(t *testing.T) {
 	key := randomHexKey(t)
 	_, dsn := testDB(t)
-	err := run(key, key, "sqlite3", dsn)
+	err := run(key, key, "sqlite3", dsn, false)
 	if err == nil {
 		t.Fatal("expected error for identical keys")
 	}
@@ -136,7 +136,7 @@ func TestRunNoEncryptedFields(t *testing.T) {
 	_, dsn := testDB(t)
 
 	// No rows in any table => should warn and exit cleanly.
-	err := run(oldKey, newKey, "sqlite3", dsn)
+	err := run(oldKey, newKey, "sqlite3", dsn, false)
 	if err != nil {
 		t.Fatalf("expected no error for empty database, got: %v", err)
 	}
@@ -178,7 +178,7 @@ func TestRunFullRotation(t *testing.T) {
 	}
 
 	// Run rotation.
-	if err := run(oldKeyHex, newKeyHex, "sqlite3", dsn); err != nil {
+	if err := run(oldKeyHex, newKeyHex, "sqlite3", dsn, false); err != nil {
 		t.Fatalf("run() error: %v", err)
 	}
 
@@ -245,7 +245,7 @@ func TestRunWrongOldKey(t *testing.T) {
 	}
 
 	// Try to rotate with the wrong old key.
-	err := run(wrongKeyHex, newKeyHex, "sqlite3", dsn)
+	err := run(wrongKeyHex, newKeyHex, "sqlite3", dsn, false)
 	if err == nil {
 		t.Fatal("expected error when old key is wrong")
 	}
@@ -266,7 +266,7 @@ func TestRunMultipleRows(t *testing.T) {
 		}
 	}
 
-	if err := run(oldKeyHex, newKeyHex, "sqlite3", dsn); err != nil {
+	if err := run(oldKeyHex, newKeyHex, "sqlite3", dsn, false); err != nil {
 		t.Fatalf("run() error: %v", err)
 	}
 
@@ -316,7 +316,7 @@ func TestRunSkipsEmptyFields(t *testing.T) {
 		t.Fatalf("insert: %v", err)
 	}
 
-	if err := run(oldKeyHex, newKeyHex, "sqlite3", dsn); err != nil {
+	if err := run(oldKeyHex, newKeyHex, "sqlite3", dsn, false); err != nil {
 		t.Fatalf("run() error: %v", err)
 	}
 
@@ -329,26 +329,26 @@ func TestRunSkipsEmptyFields(t *testing.T) {
 }
 
 func TestRunInvalidOldKeyFormat(t *testing.T) {
-	err := run("notahexkey", randomHexKey(t), "sqlite3", "file::memory:")
+	err := run("notahexkey", randomHexKey(t), "sqlite3", "file::memory:", false)
 	if err == nil {
 		t.Fatal("expected error for invalid old key format")
 	}
 }
 
 func TestRunInvalidNewKeyFormat(t *testing.T) {
-	err := run(randomHexKey(t), "tooshort", "sqlite3", "file::memory:")
+	err := run(randomHexKey(t), "tooshort", "sqlite3", "file::memory:", false)
 	if err == nil {
 		t.Fatal("expected error for invalid new key format")
 	}
 }
 
 func TestRunMissingKeys(t *testing.T) {
-	err := run("", randomHexKey(t), "sqlite3", "file::memory:")
+	err := run("", randomHexKey(t), "sqlite3", "file::memory:", false)
 	if err == nil {
 		t.Fatal("expected error for missing old key")
 	}
 
-	err = run(randomHexKey(t), "", "sqlite3", "file::memory:")
+	err = run(randomHexKey(t), "", "sqlite3", "file::memory:", false)
 	if err == nil {
 		t.Fatal("expected error for missing new key")
 	}
@@ -391,7 +391,7 @@ func TestRunMixedMarkedLegacyAndPlaintextRows(t *testing.T) {
 		}
 	}
 
-	if err := run(oldKeyHex, newKeyHex, "sqlite3", dsn); err != nil {
+	if err := run(oldKeyHex, newKeyHex, "sqlite3", dsn, false); err != nil {
 		t.Fatalf("run() error: %v", err)
 	}
 
@@ -454,7 +454,7 @@ func TestRunLegacyCiphertextRotation(t *testing.T) {
 		t.Fatalf("insert: %v", err)
 	}
 
-	if err := run(oldKeyHex, newKeyHex, "sqlite3", dsn); err != nil {
+	if err := run(oldKeyHex, newKeyHex, "sqlite3", dsn, false); err != nil {
 		t.Fatalf("run() error: %v", err)
 	}
 
@@ -483,5 +483,87 @@ func TestRunLegacyCiphertextRotation(t *testing.T) {
 		if dec != c.expected {
 			t.Errorf("%s: decrypted = %q, want %q", c.query, dec, c.expected)
 		}
+	}
+}
+
+// TestRunAbortsOnUnverifiedOldKey covers the wrong-key-on-all-legacy-database
+// hazard: every value is legacy (pre-marker) ciphertext and the operator
+// passes a wrong old key. No value positively verifies the key, so rotation
+// must hard-abort instead of wrapping garbage under the new key and printing
+// a success message.
+func TestRunAbortsOnUnverifiedOldKey(t *testing.T) {
+	correctKeyHex := randomHexKey(t)
+	wrongKeyHex := randomHexKey(t)
+	newKeyHex := randomHexKey(t)
+	db, dsn := testDB(t)
+
+	correctEnc := mustEncryptor(t, correctKeyHex)
+
+	// All-legacy database: bare base64 ciphertext, no markers.
+	legacy := strings.TrimPrefix(marked2(t, correctEnc, "secret"), crypto.EncryptedMarker)
+	if _, err := db.Exec("INSERT INTO navidrome_auths (password) VALUES (?)", legacy); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	err := run(wrongKeyHex, newKeyHex, "sqlite3", dsn, false)
+	if err == nil {
+		t.Fatal("expected hard abort when no value verifies the old key")
+	}
+	if !strings.Contains(err.Error(), "--force") {
+		t.Errorf("error should mention --force escape hatch, got: %v", err)
+	}
+
+	// The stored value must be untouched.
+	var stored string
+	if err := db.QueryRow("SELECT password FROM navidrome_auths WHERE id = 1").Scan(&stored); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if stored != legacy {
+		t.Errorf("stored value was modified despite abort: %q", stored)
+	}
+	// And still decryptable with the correct key.
+	if dec, err := correctEnc.Decrypt(stored); err != nil || dec != "secret" {
+		t.Errorf("stored value no longer decrypts with the correct key: %q, %v", dec, err)
+	}
+}
+
+// TestRunForceTreatsUnverifiedAsPlaintext verifies the --force escape hatch:
+// a pre-encryption database whose values are genuinely plaintext refuses to
+// rotate by default but proceeds with --force, encrypting every value with
+// the new key.
+func TestRunForceTreatsUnverifiedAsPlaintext(t *testing.T) {
+	oldKeyHex := randomHexKey(t)
+	newKeyHex := randomHexKey(t)
+	db, dsn := testDB(t)
+
+	plain := "just a plain password"
+	if _, err := db.Exec("INSERT INTO navidrome_auths (password) VALUES (?)", plain); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	// Without --force: hard abort.
+	if err := run(oldKeyHex, newKeyHex, "sqlite3", dsn, false); err == nil {
+		t.Fatal("expected abort for unverifiable plaintext-only database without --force")
+	}
+
+	// With --force: proceed and encrypt with the new key.
+	if err := run(oldKeyHex, newKeyHex, "sqlite3", dsn, true); err != nil {
+		t.Fatalf("run() with force error: %v", err)
+	}
+
+	newEnc := mustEncryptor(t, newKeyHex)
+	var stored string
+	if err := db.QueryRow("SELECT password FROM navidrome_auths WHERE id = 1").Scan(&stored); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if !crypto.IsEncrypted(stored) {
+		t.Errorf("stored value %q is not in the marked format", stored)
+	}
+	dec, err := newEnc.Decrypt(stored)
+	if err != nil {
+		t.Fatalf("decrypt with new key: %v", err)
+	}
+	if dec != plain {
+		t.Errorf("decrypted = %q, want %q", dec, plain)
 	}
 }

--- a/cmd/admin/main_test.go
+++ b/cmd/admin/main_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"os"
+	"strings"
 	"testing"
 
 	"spotter/internal/crypto"
@@ -350,5 +351,137 @@ func TestRunMissingKeys(t *testing.T) {
 	err = run(randomHexKey(t), "", "sqlite3", "file::memory:")
 	if err == nil {
 		t.Fatal("expected error for missing new key")
+	}
+}
+
+// TestRunMixedMarkedLegacyAndPlaintextRows verifies rotation handles all
+// three stored formats in one database (issue #335): marked ciphertext,
+// legacy unmarked ciphertext, and plaintext (including plaintext that merely
+// looks like base64 ciphertext). After rotation every value must be in the
+// marked format under the new key.
+func TestRunMixedMarkedLegacyAndPlaintextRows(t *testing.T) {
+	oldKeyHex := randomHexKey(t)
+	newKeyHex := randomHexKey(t)
+	db, dsn := testDB(t)
+
+	oldEnc := mustEncryptor(t, oldKeyHex)
+
+	// Row 1: marked (current-format) ciphertext.
+	marked, err := oldEnc.Encrypt("marked-password")
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if !crypto.IsEncrypted(marked) {
+		t.Fatalf("expected marked ciphertext, got %q", marked)
+	}
+
+	// Row 2: legacy (pre-marker) ciphertext.
+	legacy := strings.TrimPrefix(marked2(t, oldEnc, "legacy-password"), crypto.EncryptedMarker)
+
+	// Row 3: plaintext that looks like base64 ciphertext (old-heuristic
+	// false positive; stored raw by the buggy write hook).
+	lookalike := "abcdefghijklmnopqrstuvwxyzABCDEF01234567"
+
+	// Row 4: ordinary plaintext from before encryption was enabled.
+	plain := "just a plain password"
+
+	for _, pw := range []string{marked, legacy, lookalike, plain} {
+		if _, err := db.Exec("INSERT INTO navidrome_auths (password) VALUES (?)", pw); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+
+	if err := run(oldKeyHex, newKeyHex, "sqlite3", dsn); err != nil {
+		t.Fatalf("run() error: %v", err)
+	}
+
+	newEnc := mustEncryptor(t, newKeyHex)
+	want := map[int]string{
+		1: "marked-password",
+		2: "legacy-password",
+		3: lookalike,
+		4: plain,
+	}
+	for id, expected := range want {
+		var stored string
+		if err := db.QueryRow("SELECT password FROM navidrome_auths WHERE id = ?", id).Scan(&stored); err != nil {
+			t.Fatalf("select row %d: %v", id, err)
+		}
+		if !crypto.IsEncrypted(stored) {
+			t.Errorf("row %d: stored value %q is not in the marked format", id, stored)
+		}
+		dec, err := newEnc.Decrypt(stored)
+		if err != nil {
+			t.Fatalf("row %d: decrypt with new key: %v", id, err)
+		}
+		if dec != expected {
+			t.Errorf("row %d: decrypted = %q, want %q", id, dec, expected)
+		}
+	}
+}
+
+// marked2 encrypts a plaintext and fails the test on error.
+func marked2(t *testing.T, enc *crypto.Encryptor, plaintext string) string {
+	t.Helper()
+	out, err := enc.Encrypt(plaintext)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	return out
+}
+
+// TestRunLegacyCiphertextRotation verifies rotation of a database whose
+// values were all written before the marker existed (bare base64).
+func TestRunLegacyCiphertextRotation(t *testing.T) {
+	oldKeyHex := randomHexKey(t)
+	newKeyHex := randomHexKey(t)
+	db, dsn := testDB(t)
+
+	oldEnc := mustEncryptor(t, oldKeyHex)
+
+	legacyPass := strings.TrimPrefix(marked2(t, oldEnc, "navidrome-password"), crypto.EncryptedMarker)
+	legacyAccess := strings.TrimPrefix(marked2(t, oldEnc, "spotify-access"), crypto.EncryptedMarker)
+	legacyRefresh := strings.TrimPrefix(marked2(t, oldEnc, "spotify-refresh"), crypto.EncryptedMarker)
+	legacySession := strings.TrimPrefix(marked2(t, oldEnc, "lastfm-session"), crypto.EncryptedMarker)
+
+	if _, err := db.Exec("INSERT INTO navidrome_auths (password) VALUES (?)", legacyPass); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if _, err := db.Exec("INSERT INTO spotify_auths (access_token, refresh_token) VALUES (?, ?)", legacyAccess, legacyRefresh); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if _, err := db.Exec("INSERT INTO last_fm_auths (session_key, username) VALUES (?, ?)", legacySession, "testuser"); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	if err := run(oldKeyHex, newKeyHex, "sqlite3", dsn); err != nil {
+		t.Fatalf("run() error: %v", err)
+	}
+
+	newEnc := mustEncryptor(t, newKeyHex)
+	checks := []struct {
+		query    string
+		expected string
+	}{
+		{"SELECT password FROM navidrome_auths WHERE id = 1", "navidrome-password"},
+		{"SELECT access_token FROM spotify_auths WHERE id = 1", "spotify-access"},
+		{"SELECT refresh_token FROM spotify_auths WHERE id = 1", "spotify-refresh"},
+		{"SELECT session_key FROM last_fm_auths WHERE id = 1", "lastfm-session"},
+	}
+	for _, c := range checks {
+		var stored string
+		if err := db.QueryRow(c.query).Scan(&stored); err != nil {
+			t.Fatalf("%s: %v", c.query, err)
+		}
+		if !crypto.IsEncrypted(stored) {
+			t.Errorf("%s: value %q is not in the marked format", c.query, stored)
+		}
+		dec, err := newEnc.Decrypt(stored)
+		if err != nil {
+			t.Fatalf("%s: decrypt with new key: %v", c.query, err)
+		}
+		if dec != c.expected {
+			t.Errorf("%s: decrypted = %q, want %q", c.query, dec, c.expected)
+		}
 	}
 }

--- a/internal/crypto/encrypt.go
+++ b/internal/crypto/encrypt.go
@@ -1,3 +1,17 @@
+// Package crypto implements application-layer AES-256-GCM encryption for
+// credentials at rest.
+//
+// Governing: ADR-0006 (application-layer AES-256-GCM encryption for OAuth
+// credentials at rest), ADR-0021 (encryption key rotation via admin
+// subcommand).
+//
+// New ciphertext is written as EncryptedMarker + base64(nonce || ciphertext ||
+// GCM tag). The explicit versioned marker makes encrypted values
+// unambiguously identifiable: IsEncrypted is a marker check, never a
+// heuristic. Values written before the marker existed ("legacy" ciphertext,
+// bare base64) are still decryptable; LooksLikeLegacyCiphertext identifies
+// candidates for the migration paths in internal/database/hooks.go and
+// cmd/admin (rotate-key).
 package crypto
 
 import (
@@ -8,7 +22,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 )
+
+// EncryptedMarker is the versioned prefix prepended to all new ciphertext.
+// Its alphabet (':') is disjoint from std base64, so a marked value can never
+// be mistaken for legacy ciphertext or plaintext that decodes as base64.
+// Bump the version (enc:v2:) if the on-disk format ever changes.
+// Governing: ADR-0006
+const EncryptedMarker = "enc:v1:"
 
 var (
 	// ErrInvalidKey is returned when the encryption key is invalid
@@ -32,8 +54,9 @@ func NewEncryptor(key []byte) (*Encryptor, error) {
 	return &Encryptor{key: key}, nil
 }
 
-// Encrypt encrypts plaintext using AES-256-GCM and returns base64-encoded ciphertext
-// Format: base64(nonce || ciphertext || tag)
+// Encrypt encrypts plaintext using AES-256-GCM and returns marked, base64-encoded ciphertext
+// Format: EncryptedMarker + base64(nonce || ciphertext || tag)
+// Governing: ADR-0006
 func (e *Encryptor) Encrypt(plaintext string) (string, error) {
 	if plaintext == "" {
 		return "", nil
@@ -58,18 +81,24 @@ func (e *Encryptor) Encrypt(plaintext string) (string, error) {
 	// Encrypt and authenticate
 	ciphertext := gcm.Seal(nonce, nonce, []byte(plaintext), nil)
 
-	// Encode to base64 for storage
-	return base64.StdEncoding.EncodeToString(ciphertext), nil
+	// Encode to base64 for storage, with the explicit versioned marker
+	return EncryptedMarker + base64.StdEncoding.EncodeToString(ciphertext), nil
 }
 
-// Decrypt decrypts base64-encoded ciphertext using AES-256-GCM
+// Decrypt decrypts marked or legacy (unmarked) base64-encoded ciphertext using AES-256-GCM.
+// Values written before the marker was introduced are bare base64; both forms
+// are accepted so legacy rows remain readable during migration.
+// Governing: ADR-0006, ADR-0021
 func (e *Encryptor) Decrypt(ciphertext string) (string, error) {
 	if ciphertext == "" {
 		return "", nil
 	}
 
+	// Strip the versioned marker if present (legacy ciphertext has none)
+	encoded := strings.TrimPrefix(ciphertext, EncryptedMarker)
+
 	// Decode from base64
-	data, err := base64.StdEncoding.DecodeString(ciphertext)
+	data, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return "", fmt.Errorf("%w: not base64 encoded", ErrInvalidCiphertext)
 	}
@@ -98,9 +127,30 @@ func (e *Encryptor) Decrypt(ciphertext string) (string, error) {
 	return string(plaintext), nil
 }
 
-// IsEncrypted attempts to detect if a string is encrypted (base64-encoded ciphertext)
-// This is a heuristic check - it verifies if the string is valid base64 and has minimum length
+// IsEncrypted reports whether data carries the explicit versioned ciphertext
+// marker. This is an exact check, not a heuristic: only values produced by
+// Encrypt (or re-encrypted by the migration/rotation paths) match.
+//
+// This replaces the old base64-length heuristic, which false-positived on
+// plaintext such as a 40-char alphanumeric password — the write hook then
+// skipped encryption while the read interceptor attempted GCM decryption,
+// bricking the auth row (issue #335).
+// Governing: ADR-0006
 func IsEncrypted(data string) bool {
+	return strings.HasPrefix(data, EncryptedMarker)
+}
+
+// LooksLikeLegacyCiphertext reports whether data matches the shape of
+// pre-marker ciphertext: std-base64 decodable with at least
+// nonce(12) + tag(16) + 1 = 29 decoded bytes.
+//
+// This is a HEURISTIC — plaintext such as a 40-char base64-alphabet password
+// also matches — so callers MUST treat a match only as "attempt decryption"
+// and fall back to treating the value as plaintext when GCM authentication
+// fails. Used by the read-path self-healing migration in
+// internal/database/hooks.go and by the rotate-key admin subcommand.
+// Governing: ADR-0006, ADR-0021
+func LooksLikeLegacyCiphertext(data string) bool {
 	if data == "" {
 		return false
 	}
@@ -116,12 +166,12 @@ func IsEncrypted(data string) bool {
 	return len(decoded) >= 29
 }
 
-// EncryptInt encrypts an integer value and returns base64-encoded ciphertext
+// EncryptInt encrypts an integer value and returns marked, base64-encoded ciphertext
 func (e *Encryptor) EncryptInt(value int) (string, error) {
 	return e.Encrypt(fmt.Sprintf("%d", value))
 }
 
-// DecryptInt decrypts base64-encoded ciphertext and returns an integer value
+// DecryptInt decrypts marked or legacy base64-encoded ciphertext and returns an integer value
 func (e *Encryptor) DecryptInt(ciphertext string) (int, error) {
 	plaintext, err := e.Decrypt(ciphertext)
 	if err != nil {

--- a/internal/crypto/encrypt_test.go
+++ b/internal/crypto/encrypt_test.go
@@ -2,6 +2,7 @@ package crypto
 
 import (
 	"crypto/rand"
+	"strings"
 	"testing"
 )
 
@@ -169,6 +170,9 @@ func TestIsEncrypted(t *testing.T) {
 		t.Fatalf("Encrypt() error = %v", err)
 	}
 
+	// Legacy ciphertext (pre-marker format) is the marked value without its prefix
+	legacy := strings.TrimPrefix(encrypted, EncryptedMarker)
+
 	tests := []struct {
 		name string
 		data string
@@ -179,12 +183,108 @@ func TestIsEncrypted(t *testing.T) {
 		{"empty string", "", false},
 		{"short base64", "YWJj", false},
 		{"not base64", "plain text password!", false},
+		// The old heuristic false-positived on these (issue #335):
+		{"40-char base64-alphabet password", "abcdefghijklmnopqrstuvwxyzABCDEF01234567", false},
+		{"legacy unmarked ciphertext", legacy, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := IsEncrypted(tt.data); got != tt.want {
 				t.Errorf("IsEncrypted() = %v, want %v for %q", got, tt.want, tt.data)
+			}
+		})
+	}
+}
+
+func TestEncryptProducesMarker(t *testing.T) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	encryptor, err := NewEncryptor(key)
+	if err != nil {
+		t.Fatalf("failed to create encryptor: %v", err)
+	}
+
+	encrypted, err := encryptor.Encrypt("mypassword")
+	if err != nil {
+		t.Fatalf("Encrypt() error = %v", err)
+	}
+
+	if !strings.HasPrefix(encrypted, EncryptedMarker) {
+		t.Errorf("Encrypt() output %q does not start with marker %q", encrypted, EncryptedMarker)
+	}
+	if !IsEncrypted(encrypted) {
+		t.Errorf("IsEncrypted() = false for freshly encrypted value %q", encrypted)
+	}
+}
+
+func TestDecryptLegacyUnmarkedCiphertext(t *testing.T) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	encryptor, err := NewEncryptor(key)
+	if err != nil {
+		t.Fatalf("failed to create encryptor: %v", err)
+	}
+
+	plaintext := "legacy-secret"
+	encrypted, err := encryptor.Encrypt(plaintext)
+	if err != nil {
+		t.Fatalf("Encrypt() error = %v", err)
+	}
+
+	// Simulate a row written before the marker was introduced
+	legacy := strings.TrimPrefix(encrypted, EncryptedMarker)
+
+	decrypted, err := encryptor.Decrypt(legacy)
+	if err != nil {
+		t.Fatalf("Decrypt() error on legacy ciphertext: %v", err)
+	}
+	if decrypted != plaintext {
+		t.Errorf("Decrypt(legacy) = %q, want %q", decrypted, plaintext)
+	}
+}
+
+func TestLooksLikeLegacyCiphertext(t *testing.T) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	encryptor, err := NewEncryptor(key)
+	if err != nil {
+		t.Fatalf("failed to create encryptor: %v", err)
+	}
+
+	encrypted, err := encryptor.Encrypt("mypassword")
+	if err != nil {
+		t.Fatalf("Encrypt() error = %v", err)
+	}
+	legacy := strings.TrimPrefix(encrypted, EncryptedMarker)
+
+	tests := []struct {
+		name string
+		data string
+		want bool
+	}{
+		{"legacy unmarked ciphertext", legacy, true},
+		// Ambiguous by design: the heuristic matches, callers must fall back on GCM failure
+		{"40-char base64-alphabet password", "abcdefghijklmnopqrstuvwxyzABCDEF01234567", true},
+		{"marked ciphertext", encrypted, false},
+		{"plaintext password", "mypassword", false},
+		{"empty string", "", false},
+		{"short base64", "YWJj", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := LooksLikeLegacyCiphertext(tt.data); got != tt.want {
+				t.Errorf("LooksLikeLegacyCiphertext() = %v, want %v for %q", got, tt.want, tt.data)
 			}
 		})
 	}

--- a/internal/database/hooks.go
+++ b/internal/database/hooks.go
@@ -10,24 +10,76 @@ import (
 )
 
 // RegisterEncryptionHooks registers hooks to encrypt/decrypt sensitive data
+// Governing: ADR-0006 (application-layer AES-256-GCM encryption via Ent hooks)
 func RegisterEncryptionHooks(client *ent.Client, encryptor *crypto.Encryptor) {
 	// Hook for encrypting password on NavidromeAuth create/update
 	client.NavidromeAuth.Use(encryptPasswordHook(encryptor))
 
 	// Hook for decrypting password on NavidromeAuth query
-	client.NavidromeAuth.Intercept(decryptPasswordInterceptor(encryptor))
+	client.NavidromeAuth.Intercept(decryptPasswordInterceptor(client, encryptor))
 
 	// Hook for encrypting tokens on SpotifyAuth create/update
 	client.SpotifyAuth.Use(encryptSpotifyAuthHook(encryptor))
 
 	// Hook for decrypting tokens on SpotifyAuth query
-	client.SpotifyAuth.Intercept(decryptSpotifyAuthInterceptor(encryptor))
+	client.SpotifyAuth.Intercept(decryptSpotifyAuthInterceptor(client, encryptor))
 
 	// Hook for encrypting session key on LastFMAuth create/update
 	client.LastFMAuth.Use(encryptLastFMAuthHook(encryptor))
 
 	// Hook for decrypting session key on LastFMAuth query
-	client.LastFMAuth.Intercept(decryptLastFMAuthInterceptor(encryptor))
+	client.LastFMAuth.Intercept(decryptLastFMAuthInterceptor(client, encryptor))
+}
+
+// resolveEncryptedField returns the plaintext for a stored credential value
+// and, when the stored form is legacy, a marked ciphertext to write back
+// (self-heal). Resolution order:
+//
+//  1. Explicit marker (enc:v1:) → decrypt; a failure here is a real error
+//     (wrong key or corrupted ciphertext) and is returned to the caller.
+//  2. Legacy ciphertext shape (bare base64, >= 29 decoded bytes) → attempt
+//     decryption. Success means it is pre-marker ciphertext; GCM failure
+//     means it is plaintext that merely looks like ciphertext (e.g. a
+//     40-char alphanumeric password). Either way the row self-heals: the
+//     plaintext is re-encrypted with the marker and returned as healed.
+//     This path NEVER returns an error — previously it bricked the auth row
+//     by failing the whole query (issue #335).
+//  3. Anything else is plaintext from before encryption was enabled; it is
+//     left as-is and will be encrypted on the next write.
+//
+// Governing: ADR-0006
+func resolveEncryptedField(encryptor *crypto.Encryptor, stored string) (plaintext, healed string, err error) {
+	if stored == "" {
+		return "", "", nil
+	}
+
+	if crypto.IsEncrypted(stored) {
+		decrypted, err := encryptor.Decrypt(stored)
+		if err != nil {
+			return "", "", err
+		}
+		return decrypted, "", nil
+	}
+
+	if crypto.LooksLikeLegacyCiphertext(stored) {
+		if decrypted, err := encryptor.Decrypt(stored); err == nil {
+			// Legacy ciphertext: migrate to the marked format.
+			if reencrypted, err := encryptor.Encrypt(decrypted); err == nil {
+				return decrypted, reencrypted, nil
+			}
+			return decrypted, "", nil
+		}
+		// GCM failure: the value is plaintext that merely looks like
+		// ciphertext. Treat it as plaintext and self-heal by encrypting
+		// it with the marker so future reads are unambiguous.
+		if reencrypted, err := encryptor.Encrypt(stored); err == nil {
+			return stored, reencrypted, nil
+		}
+		return stored, "", nil
+	}
+
+	// Plaintext from before encryption was enabled (will be encrypted on next write)
+	return stored, "", nil
 }
 
 // encryptPasswordHook encrypts the password field before saving to database
@@ -67,7 +119,7 @@ func encryptPasswordHook(encryptor *crypto.Encryptor) ent.Hook {
 }
 
 // decryptPasswordInterceptor decrypts password fields after loading from database
-func decryptPasswordInterceptor(encryptor *crypto.Encryptor) ent.Interceptor {
+func decryptPasswordInterceptor(client *ent.Client, encryptor *crypto.Encryptor) ent.Interceptor {
 	return ent.InterceptFunc(func(next ent.Querier) ent.Querier {
 		return ent.QuerierFunc(func(ctx context.Context, q ent.Query) (ent.Value, error) {
 			// Execute the query
@@ -79,12 +131,12 @@ func decryptPasswordInterceptor(encryptor *crypto.Encryptor) ent.Interceptor {
 			// Decrypt passwords in the results
 			switch result := v.(type) {
 			case *ent.NavidromeAuth:
-				if err := decryptNavidromeAuth(encryptor, result); err != nil {
+				if err := decryptNavidromeAuth(ctx, client, encryptor, result); err != nil {
 					return nil, err
 				}
 			case []*ent.NavidromeAuth:
 				for _, auth := range result {
-					if err := decryptNavidromeAuth(encryptor, auth); err != nil {
+					if err := decryptNavidromeAuth(ctx, client, encryptor, auth); err != nil {
 						return nil, err
 					}
 				}
@@ -95,21 +147,24 @@ func decryptPasswordInterceptor(encryptor *crypto.Encryptor) ent.Interceptor {
 	})
 }
 
-// decryptNavidromeAuth decrypts the password field in a NavidromeAuth entity
-func decryptNavidromeAuth(encryptor *crypto.Encryptor, auth *ent.NavidromeAuth) error {
+// decryptNavidromeAuth decrypts the password field in a NavidromeAuth entity,
+// self-healing legacy-format rows to the marked ciphertext format.
+func decryptNavidromeAuth(ctx context.Context, client *ent.Client, encryptor *crypto.Encryptor, auth *ent.NavidromeAuth) error {
 	if auth == nil || auth.Password == "" {
 		return nil
 	}
 
-	// Check if password is encrypted (backward compatibility)
-	if crypto.IsEncrypted(auth.Password) {
-		decrypted, err := encryptor.Decrypt(auth.Password)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt password for user %d: %w", auth.ID, err)
-		}
-		auth.Password = decrypted
+	plaintext, healed, err := resolveEncryptedField(encryptor, auth.Password)
+	if err != nil {
+		return fmt.Errorf("failed to decrypt password for user %d: %w", auth.ID, err)
 	}
-	// If not encrypted, leave as-is (will be encrypted on next update)
+	if healed != "" {
+		// Best-effort self-heal: persist the marked ciphertext. The write
+		// hook sees the marker and stores it as-is. Failures are ignored —
+		// the read must never break, and the next read retries the heal.
+		_ = client.NavidromeAuth.UpdateOneID(auth.ID).SetPassword(healed).Exec(ctx)
+	}
+	auth.Password = plaintext
 
 	return nil
 }
@@ -170,7 +225,7 @@ func encryptSpotifyAuthHook(encryptor *crypto.Encryptor) ent.Hook {
 }
 
 // decryptSpotifyAuthInterceptor decrypts access_token and refresh_token fields after loading from database
-func decryptSpotifyAuthInterceptor(encryptor *crypto.Encryptor) ent.Interceptor {
+func decryptSpotifyAuthInterceptor(client *ent.Client, encryptor *crypto.Encryptor) ent.Interceptor {
 	return ent.InterceptFunc(func(next ent.Querier) ent.Querier {
 		return ent.QuerierFunc(func(ctx context.Context, q ent.Query) (ent.Value, error) {
 			// Execute the query
@@ -182,12 +237,12 @@ func decryptSpotifyAuthInterceptor(encryptor *crypto.Encryptor) ent.Interceptor 
 			// Decrypt tokens in the results
 			switch result := v.(type) {
 			case *ent.SpotifyAuth:
-				if err := decryptSpotifyAuth(encryptor, result); err != nil {
+				if err := decryptSpotifyAuth(ctx, client, encryptor, result); err != nil {
 					return nil, err
 				}
 			case []*ent.SpotifyAuth:
 				for _, auth := range result {
-					if err := decryptSpotifyAuth(encryptor, auth); err != nil {
+					if err := decryptSpotifyAuth(ctx, client, encryptor, auth); err != nil {
 						return nil, err
 					}
 				}
@@ -198,31 +253,41 @@ func decryptSpotifyAuthInterceptor(encryptor *crypto.Encryptor) ent.Interceptor 
 	})
 }
 
-// decryptSpotifyAuth decrypts the access_token and refresh_token fields in a SpotifyAuth entity
-func decryptSpotifyAuth(encryptor *crypto.Encryptor, auth *ent.SpotifyAuth) error {
+// decryptSpotifyAuth decrypts the access_token and refresh_token fields in a
+// SpotifyAuth entity, self-healing legacy-format values to the marked
+// ciphertext format.
+func decryptSpotifyAuth(ctx context.Context, client *ent.Client, encryptor *crypto.Encryptor, auth *ent.SpotifyAuth) error {
 	if auth == nil {
 		return nil
 	}
 
-	// Decrypt access_token if encrypted (backward compatibility)
-	if auth.AccessToken != "" && crypto.IsEncrypted(auth.AccessToken) {
-		decrypted, err := encryptor.Decrypt(auth.AccessToken)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt access_token for user %d: %w", auth.ID, err)
-		}
-		auth.AccessToken = decrypted
+	accessPlain, accessHealed, err := resolveEncryptedField(encryptor, auth.AccessToken)
+	if err != nil {
+		return fmt.Errorf("failed to decrypt access_token for user %d: %w", auth.ID, err)
 	}
 
-	// Decrypt refresh_token if encrypted (backward compatibility)
-	if auth.RefreshToken != "" && crypto.IsEncrypted(auth.RefreshToken) {
-		decrypted, err := encryptor.Decrypt(auth.RefreshToken)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt refresh_token for user %d: %w", auth.ID, err)
-		}
-		auth.RefreshToken = decrypted
+	refreshPlain, refreshHealed, err := resolveEncryptedField(encryptor, auth.RefreshToken)
+	if err != nil {
+		return fmt.Errorf("failed to decrypt refresh_token for user %d: %w", auth.ID, err)
 	}
 
-	// If not encrypted, leave as-is (will be encrypted on next update)
+	if accessHealed != "" || refreshHealed != "" {
+		// Best-effort self-heal: persist the marked ciphertexts. The write
+		// hook sees the marker and stores them as-is. Failures are ignored —
+		// the read must never break, and the next read retries the heal.
+		update := client.SpotifyAuth.UpdateOneID(auth.ID)
+		if accessHealed != "" {
+			update.SetAccessToken(accessHealed)
+		}
+		if refreshHealed != "" {
+			update.SetRefreshToken(refreshHealed)
+		}
+		_ = update.Exec(ctx)
+	}
+
+	auth.AccessToken = accessPlain
+	auth.RefreshToken = refreshPlain
+
 	return nil
 }
 
@@ -264,7 +329,7 @@ func encryptLastFMAuthHook(encryptor *crypto.Encryptor) ent.Hook {
 }
 
 // decryptLastFMAuthInterceptor decrypts session_key field after loading from database
-func decryptLastFMAuthInterceptor(encryptor *crypto.Encryptor) ent.Interceptor {
+func decryptLastFMAuthInterceptor(client *ent.Client, encryptor *crypto.Encryptor) ent.Interceptor {
 	return ent.InterceptFunc(func(next ent.Querier) ent.Querier {
 		return ent.QuerierFunc(func(ctx context.Context, q ent.Query) (ent.Value, error) {
 			// Execute the query
@@ -276,12 +341,12 @@ func decryptLastFMAuthInterceptor(encryptor *crypto.Encryptor) ent.Interceptor {
 			// Decrypt session_key in the results
 			switch result := v.(type) {
 			case *ent.LastFMAuth:
-				if err := decryptLastFMAuth(encryptor, result); err != nil {
+				if err := decryptLastFMAuth(ctx, client, encryptor, result); err != nil {
 					return nil, err
 				}
 			case []*ent.LastFMAuth:
 				for _, auth := range result {
-					if err := decryptLastFMAuth(encryptor, auth); err != nil {
+					if err := decryptLastFMAuth(ctx, client, encryptor, auth); err != nil {
 						return nil, err
 					}
 				}
@@ -292,21 +357,24 @@ func decryptLastFMAuthInterceptor(encryptor *crypto.Encryptor) ent.Interceptor {
 	})
 }
 
-// decryptLastFMAuth decrypts the session_key field in a LastFMAuth entity
-func decryptLastFMAuth(encryptor *crypto.Encryptor, auth *ent.LastFMAuth) error {
+// decryptLastFMAuth decrypts the session_key field in a LastFMAuth entity,
+// self-healing legacy-format rows to the marked ciphertext format.
+func decryptLastFMAuth(ctx context.Context, client *ent.Client, encryptor *crypto.Encryptor, auth *ent.LastFMAuth) error {
 	if auth == nil || auth.SessionKey == "" {
 		return nil
 	}
 
-	// Check if session_key is encrypted (backward compatibility)
-	if crypto.IsEncrypted(auth.SessionKey) {
-		decrypted, err := encryptor.Decrypt(auth.SessionKey)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt session_key for user %d: %w", auth.ID, err)
-		}
-		auth.SessionKey = decrypted
+	plaintext, healed, err := resolveEncryptedField(encryptor, auth.SessionKey)
+	if err != nil {
+		return fmt.Errorf("failed to decrypt session_key for user %d: %w", auth.ID, err)
 	}
-	// If not encrypted, leave as-is (will be encrypted on next update)
+	if healed != "" {
+		// Best-effort self-heal: persist the marked ciphertext. The write
+		// hook sees the marker and stores it as-is. Failures are ignored —
+		// the read must never break, and the next read retries the heal.
+		_ = client.LastFMAuth.UpdateOneID(auth.ID).SetSessionKey(healed).Exec(ctx)
+	}
+	auth.SessionKey = plaintext
 
 	return nil
 }

--- a/internal/database/hooks.go
+++ b/internal/database/hooks.go
@@ -3,11 +3,37 @@ package database
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"spotter/ent"
 	"spotter/ent/hook"
+	"spotter/ent/lastfmauth"
+	"spotter/ent/navidromeauth"
+	"spotter/ent/spotifyauth"
 	"spotter/internal/crypto"
 )
+
+// selfHealCtxKey marks a context as belonging to an interceptor self-heal
+// write-back, whose value is already marked ciphertext and must be stored
+// as-is. Every other mutation carries user input and is ALWAYS encrypted —
+// even input that happens to start with the enc:v1: marker. Deciding by
+// value shape in the write hooks would re-open the bricking bug this
+// package exists to fix: a password literally starting with "enc:v1:"
+// would be stored as plaintext and then fail GCM decryption on every read
+// (issue #335).
+type selfHealCtxKey struct{}
+
+// withSelfHeal returns a context that tells the write hooks to store the
+// (already marked-ciphertext) value without re-encrypting it.
+func withSelfHeal(ctx context.Context) context.Context {
+	return context.WithValue(ctx, selfHealCtxKey{}, true)
+}
+
+// isSelfHeal reports whether ctx belongs to an interceptor self-heal write-back.
+func isSelfHeal(ctx context.Context) bool {
+	v, _ := ctx.Value(selfHealCtxKey{}).(bool)
+	return v
+}
 
 // RegisterEncryptionHooks registers hooks to encrypt/decrypt sensitive data
 // Governing: ADR-0006 (application-layer AES-256-GCM encryption via Ent hooks)
@@ -40,46 +66,50 @@ func RegisterEncryptionHooks(client *ent.Client, encryptor *crypto.Encryptor) {
 //  2. Legacy ciphertext shape (bare base64, >= 29 decoded bytes) → attempt
 //     decryption. Success means it is pre-marker ciphertext; GCM failure
 //     means it is plaintext that merely looks like ciphertext (e.g. a
-//     40-char alphanumeric password). Either way the row self-heals: the
-//     plaintext is re-encrypted with the marker and returned as healed.
-//     This path NEVER returns an error — previously it bricked the auth row
-//     by failing the whole query (issue #335).
+//     40-char alphanumeric password) — reported via treatedAsPlaintext so
+//     callers can log it, since it is also the only signal an operator gets
+//     when the encryption key is wrong for legacy rows. Either way the row
+//     self-heals: the plaintext is re-encrypted with the marker and returned
+//     as healed. This path NEVER returns an error — previously it bricked
+//     the auth row by failing the whole query (issue #335).
 //  3. Anything else is plaintext from before encryption was enabled; it is
 //     left as-is and will be encrypted on the next write.
 //
 // Governing: ADR-0006
-func resolveEncryptedField(encryptor *crypto.Encryptor, stored string) (plaintext, healed string, err error) {
+func resolveEncryptedField(encryptor *crypto.Encryptor, stored string) (plaintext, healed string, treatedAsPlaintext bool, err error) {
 	if stored == "" {
-		return "", "", nil
+		return "", "", false, nil
 	}
 
 	if crypto.IsEncrypted(stored) {
 		decrypted, err := encryptor.Decrypt(stored)
 		if err != nil {
-			return "", "", err
+			// Marked values are always ciphertext (the write hooks encrypt
+			// unconditionally), so this can only be a wrong key or corruption.
+			return "", "", false, err
 		}
-		return decrypted, "", nil
+		return decrypted, "", false, nil
 	}
 
 	if crypto.LooksLikeLegacyCiphertext(stored) {
 		if decrypted, err := encryptor.Decrypt(stored); err == nil {
 			// Legacy ciphertext: migrate to the marked format.
 			if reencrypted, err := encryptor.Encrypt(decrypted); err == nil {
-				return decrypted, reencrypted, nil
+				return decrypted, reencrypted, false, nil
 			}
-			return decrypted, "", nil
+			return decrypted, "", false, nil
 		}
 		// GCM failure: the value is plaintext that merely looks like
 		// ciphertext. Treat it as plaintext and self-heal by encrypting
 		// it with the marker so future reads are unambiguous.
 		if reencrypted, err := encryptor.Encrypt(stored); err == nil {
-			return stored, reencrypted, nil
+			return stored, reencrypted, true, nil
 		}
-		return stored, "", nil
+		return stored, "", true, nil
 	}
 
 	// Plaintext from before encryption was enabled (will be encrypted on next write)
-	return stored, "", nil
+	return stored, "", false, nil
 }
 
 // encryptPasswordHook encrypts the password field before saving to database
@@ -91,8 +121,11 @@ func encryptPasswordHook(encryptor *crypto.Encryptor) ent.Hook {
 			var originalPassword string
 			if password, exists := m.Password(); exists {
 				originalPassword = password
-				// Check if already encrypted (for idempotency)
-				if !crypto.IsEncrypted(password) {
+				// ALWAYS encrypt user input — even input that happens to
+				// start with the enc:v1: marker (issue #335). Only the
+				// interceptor self-heal path, which writes back values that
+				// are already marked ciphertext, may skip encryption.
+				if !isSelfHeal(ctx) {
 					// Encrypt the password
 					encrypted, err := encryptor.Encrypt(password)
 					if err != nil {
@@ -154,15 +187,24 @@ func decryptNavidromeAuth(ctx context.Context, client *ent.Client, encryptor *cr
 		return nil
 	}
 
-	plaintext, healed, err := resolveEncryptedField(encryptor, auth.Password)
+	plaintext, healed, treatedAsPlaintext, err := resolveEncryptedField(encryptor, auth.Password)
 	if err != nil {
 		return fmt.Errorf("failed to decrypt password for user %d: %w", auth.ID, err)
 	}
+	if treatedAsPlaintext {
+		slog.Warn("stored navidrome password matches legacy ciphertext shape but fails decryption; treating as plaintext and re-encrypting (wrong SPOTTER_SECURITY_ENCRYPTION_KEY?)",
+			"navidrome_auth_id", auth.ID)
+	}
 	if healed != "" {
-		// Best-effort self-heal: persist the marked ciphertext. The write
-		// hook sees the marker and stores it as-is. Failures are ignored —
-		// the read must never break, and the next read retries the heal.
-		_ = client.NavidromeAuth.UpdateOneID(auth.ID).SetPassword(healed).Exec(ctx)
+		// Best-effort self-heal: persist the marked ciphertext. The
+		// self-heal context tells the write hook to store it as-is, and
+		// the Where guard makes it a compare-and-swap so a concurrent
+		// legitimate credential update is never clobbered. Failures are
+		// ignored — the read must never break; the next read retries.
+		_, _ = client.NavidromeAuth.Update().
+			Where(navidromeauth.ID(auth.ID), navidromeauth.Password(auth.Password)).
+			SetPassword(healed).
+			Save(withSelfHeal(ctx))
 	}
 	auth.Password = plaintext
 
@@ -177,11 +219,12 @@ func encryptSpotifyAuthHook(encryptor *crypto.Encryptor) ent.Hook {
 			// Remember original tokens for decryption after save
 			var originalAccessToken, originalRefreshToken string
 
-			// Encrypt access_token if being set
+			// Encrypt access_token if being set. ALWAYS encrypt user input —
+			// even input starting with the enc:v1: marker (issue #335); only
+			// the interceptor self-heal path may skip encryption.
 			if accessToken, exists := m.AccessToken(); exists {
 				originalAccessToken = accessToken
-				// Check if already encrypted (for idempotency)
-				if !crypto.IsEncrypted(accessToken) {
+				if !isSelfHeal(ctx) {
 					encrypted, err := encryptor.Encrypt(accessToken)
 					if err != nil {
 						return nil, fmt.Errorf("failed to encrypt access_token: %w", err)
@@ -190,11 +233,10 @@ func encryptSpotifyAuthHook(encryptor *crypto.Encryptor) ent.Hook {
 				}
 			}
 
-			// Encrypt refresh_token if being set
+			// Encrypt refresh_token if being set (same self-heal rule as above)
 			if refreshToken, exists := m.RefreshToken(); exists {
 				originalRefreshToken = refreshToken
-				// Check if already encrypted (for idempotency)
-				if !crypto.IsEncrypted(refreshToken) {
+				if !isSelfHeal(ctx) {
 					encrypted, err := encryptor.Encrypt(refreshToken)
 					if err != nil {
 						return nil, fmt.Errorf("failed to encrypt refresh_token: %w", err)
@@ -261,28 +303,40 @@ func decryptSpotifyAuth(ctx context.Context, client *ent.Client, encryptor *cryp
 		return nil
 	}
 
-	accessPlain, accessHealed, err := resolveEncryptedField(encryptor, auth.AccessToken)
+	accessPlain, accessHealed, accessAsPlaintext, err := resolveEncryptedField(encryptor, auth.AccessToken)
 	if err != nil {
 		return fmt.Errorf("failed to decrypt access_token for user %d: %w", auth.ID, err)
 	}
+	if accessAsPlaintext {
+		slog.Warn("stored spotify access_token matches legacy ciphertext shape but fails decryption; treating as plaintext and re-encrypting (wrong SPOTTER_SECURITY_ENCRYPTION_KEY?)",
+			"spotify_auth_id", auth.ID)
+	}
 
-	refreshPlain, refreshHealed, err := resolveEncryptedField(encryptor, auth.RefreshToken)
+	refreshPlain, refreshHealed, refreshAsPlaintext, err := resolveEncryptedField(encryptor, auth.RefreshToken)
 	if err != nil {
 		return fmt.Errorf("failed to decrypt refresh_token for user %d: %w", auth.ID, err)
 	}
+	if refreshAsPlaintext {
+		slog.Warn("stored spotify refresh_token matches legacy ciphertext shape but fails decryption; treating as plaintext and re-encrypting (wrong SPOTTER_SECURITY_ENCRYPTION_KEY?)",
+			"spotify_auth_id", auth.ID)
+	}
 
-	if accessHealed != "" || refreshHealed != "" {
-		// Best-effort self-heal: persist the marked ciphertexts. The write
-		// hook sees the marker and stores them as-is. Failures are ignored —
-		// the read must never break, and the next read retries the heal.
-		update := client.SpotifyAuth.UpdateOneID(auth.ID)
-		if accessHealed != "" {
-			update.SetAccessToken(accessHealed)
-		}
-		if refreshHealed != "" {
-			update.SetRefreshToken(refreshHealed)
-		}
-		_ = update.Exec(ctx)
+	// Best-effort self-heal: persist the marked ciphertexts. The self-heal
+	// context tells the write hook to store them as-is, and the Where guards
+	// make each write a compare-and-swap so a concurrent legitimate
+	// credential update is never clobbered. Failures are ignored — the read
+	// must never break; the next read retries.
+	if accessHealed != "" {
+		_, _ = client.SpotifyAuth.Update().
+			Where(spotifyauth.ID(auth.ID), spotifyauth.AccessToken(auth.AccessToken)).
+			SetAccessToken(accessHealed).
+			Save(withSelfHeal(ctx))
+	}
+	if refreshHealed != "" {
+		_, _ = client.SpotifyAuth.Update().
+			Where(spotifyauth.ID(auth.ID), spotifyauth.RefreshToken(auth.RefreshToken)).
+			SetRefreshToken(refreshHealed).
+			Save(withSelfHeal(ctx))
 	}
 
 	auth.AccessToken = accessPlain
@@ -299,11 +353,12 @@ func encryptLastFMAuthHook(encryptor *crypto.Encryptor) ent.Hook {
 			// Remember original session_key for decryption after save
 			var originalSessionKey string
 
-			// Encrypt session_key if being set
+			// Encrypt session_key if being set. ALWAYS encrypt user input —
+			// even input starting with the enc:v1: marker (issue #335); only
+			// the interceptor self-heal path may skip encryption.
 			if sessionKey, exists := m.SessionKey(); exists {
 				originalSessionKey = sessionKey
-				// Check if already encrypted (for idempotency)
-				if !crypto.IsEncrypted(sessionKey) {
+				if !isSelfHeal(ctx) {
 					encrypted, err := encryptor.Encrypt(sessionKey)
 					if err != nil {
 						return nil, fmt.Errorf("failed to encrypt session_key: %w", err)
@@ -364,15 +419,24 @@ func decryptLastFMAuth(ctx context.Context, client *ent.Client, encryptor *crypt
 		return nil
 	}
 
-	plaintext, healed, err := resolveEncryptedField(encryptor, auth.SessionKey)
+	plaintext, healed, treatedAsPlaintext, err := resolveEncryptedField(encryptor, auth.SessionKey)
 	if err != nil {
 		return fmt.Errorf("failed to decrypt session_key for user %d: %w", auth.ID, err)
 	}
+	if treatedAsPlaintext {
+		slog.Warn("stored lastfm session_key matches legacy ciphertext shape but fails decryption; treating as plaintext and re-encrypting (wrong SPOTTER_SECURITY_ENCRYPTION_KEY?)",
+			"lastfm_auth_id", auth.ID)
+	}
 	if healed != "" {
-		// Best-effort self-heal: persist the marked ciphertext. The write
-		// hook sees the marker and stores it as-is. Failures are ignored —
-		// the read must never break, and the next read retries the heal.
-		_ = client.LastFMAuth.UpdateOneID(auth.ID).SetSessionKey(healed).Exec(ctx)
+		// Best-effort self-heal: persist the marked ciphertext. The
+		// self-heal context tells the write hook to store it as-is, and
+		// the Where guard makes it a compare-and-swap so a concurrent
+		// legitimate credential update is never clobbered. Failures are
+		// ignored — the read must never break; the next read retries.
+		_, _ = client.LastFMAuth.Update().
+			Where(lastfmauth.ID(auth.ID), lastfmauth.SessionKey(auth.SessionKey)).
+			SetSessionKey(healed).
+			Save(withSelfHeal(ctx))
 	}
 	auth.SessionKey = plaintext
 

--- a/internal/database/hooks_test.go
+++ b/internal/database/hooks_test.go
@@ -3,6 +3,8 @@ package database
 import (
 	"context"
 	"crypto/rand"
+	"database/sql"
+	"strings"
 	"testing"
 	"time"
 
@@ -538,5 +540,258 @@ func TestMultipleAuthRecords(t *testing.T) {
 		if auth.RefreshToken != expectedRefresh {
 			t.Errorf("auth[%d]: expected refresh_token %q, got %q", i, expectedRefresh, auth.RefreshToken)
 		}
+	}
+}
+
+// rawColumnValue reads the raw stored value of a column, bypassing Ent and
+// the decrypt interceptors, via a second connection to the same shared-cache
+// in-memory database.
+func rawColumnValue(t *testing.T, dsn, query string, args ...interface{}) string {
+	t.Helper()
+	rawDB, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		t.Fatalf("failed to open raw db: %v", err)
+	}
+	defer rawDB.Close()
+
+	var value string
+	if err := rawDB.QueryRow(query, args...).Scan(&value); err != nil {
+		t.Fatalf("failed to read raw value: %v", err)
+	}
+	return value
+}
+
+// TestBase64LookalikePasswordRoundTrip covers the auth-row bricking bug from
+// issue #335: a 40-char base64-alphabet password false-positived the old
+// IsEncrypted heuristic, so the write hook skipped encryption and the read
+// interceptor then failed GCM authentication, erroring every query for the
+// row. With the explicit marker the password must round-trip and be stored
+// encrypted.
+func TestBase64LookalikePasswordRoundTrip(t *testing.T) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	encryptor, err := crypto.NewEncryptor(key)
+	if err != nil {
+		t.Fatalf("failed to create encryptor: %v", err)
+	}
+
+	dsn := "file:ent_lookalike?mode=memory&cache=shared&_fk=1"
+	client, err := ent.Open("sqlite3", dsn)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer client.Close()
+
+	RegisterEncryptionHooks(client, encryptor)
+
+	if err := client.Schema.Create(context.Background()); err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	ctx := context.Background()
+
+	user, err := client.User.Create().
+		SetUsername("testuser").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+
+	// 40 chars, pure base64 alphabet, decodes to 30 bytes — the old
+	// heuristic treated this plaintext as ciphertext.
+	password := "abcdefghijklmnopqrstuvwxyzABCDEF01234567"
+
+	auth, err := client.NavidromeAuth.Create().
+		SetUser(user).
+		SetPassword(password).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("failed to create navidrome auth: %v", err)
+	}
+	if auth.Password != password {
+		t.Errorf("password after create = %q, want %q", auth.Password, password)
+	}
+
+	// This read used to fail with a GCM authentication error.
+	authFromDB, err := client.NavidromeAuth.Get(ctx, auth.ID)
+	if err != nil {
+		t.Fatalf("failed to query navidrome auth (bricked row, issue #335): %v", err)
+	}
+	if authFromDB.Password != password {
+		t.Errorf("password after query = %q, want %q", authFromDB.Password, password)
+	}
+
+	// Verify the stored value is marked ciphertext, not plaintext.
+	raw := rawColumnValue(t, dsn, "SELECT password FROM navidrome_auths WHERE id = ?", auth.ID)
+	if raw == password {
+		t.Errorf("password stored as plaintext, want marked ciphertext")
+	}
+	if !crypto.IsEncrypted(raw) {
+		t.Errorf("stored password %q does not carry the encryption marker", raw)
+	}
+	decrypted, err := encryptor.Decrypt(raw)
+	if err != nil {
+		t.Fatalf("failed to decrypt stored password: %v", err)
+	}
+	if decrypted != password {
+		t.Errorf("decrypted stored password = %q, want %q", decrypted, password)
+	}
+}
+
+// TestPlaintextLookalikeSelfHealsOnRead simulates a row bricked by the old
+// heuristic: plaintext that looks like base64 ciphertext was stored raw
+// (write hook skipped encryption). Reading it must not error; instead the
+// value is treated as plaintext and the row self-heals to marked ciphertext.
+func TestPlaintextLookalikeSelfHealsOnRead(t *testing.T) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	encryptor, err := crypto.NewEncryptor(key)
+	if err != nil {
+		t.Fatalf("failed to create encryptor: %v", err)
+	}
+
+	dsn := "file:ent_selfheal?mode=memory&cache=shared&_fk=1"
+	client, err := ent.Open("sqlite3", dsn)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer client.Close()
+
+	if err := client.Schema.Create(context.Background()); err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	ctx := context.Background()
+
+	user, err := client.User.Create().
+		SetUsername("testuser").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+
+	// Store the lookalike plaintext raw (no hooks yet), simulating a row
+	// written while the old heuristic skipped encryption.
+	password := "abcdefghijklmnopqrstuvwxyzABCDEF01234567"
+	auth, err := client.NavidromeAuth.Create().
+		SetUser(user).
+		SetPassword(password).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("failed to create auth: %v", err)
+	}
+
+	RegisterEncryptionHooks(client, encryptor)
+
+	// This read used to error the whole query (GCM failure on plaintext).
+	authFromDB, err := client.NavidromeAuth.Get(ctx, auth.ID)
+	if err != nil {
+		t.Fatalf("read of plaintext-lookalike row errored instead of self-healing: %v", err)
+	}
+	if authFromDB.Password != password {
+		t.Errorf("password = %q, want %q", authFromDB.Password, password)
+	}
+
+	// The row must have self-healed: stored value is now marked ciphertext.
+	raw := rawColumnValue(t, dsn, "SELECT password FROM navidrome_auths WHERE id = ?", auth.ID)
+	if !crypto.IsEncrypted(raw) {
+		t.Fatalf("row did not self-heal: stored value %q has no marker", raw)
+	}
+	decrypted, err := encryptor.Decrypt(raw)
+	if err != nil {
+		t.Fatalf("failed to decrypt self-healed value: %v", err)
+	}
+	if decrypted != password {
+		t.Errorf("self-healed value decrypts to %q, want %q", decrypted, password)
+	}
+
+	// Subsequent reads keep working.
+	again, err := client.NavidromeAuth.Get(ctx, auth.ID)
+	if err != nil {
+		t.Fatalf("failed to re-read self-healed row: %v", err)
+	}
+	if again.Password != password {
+		t.Errorf("password after self-heal = %q, want %q", again.Password, password)
+	}
+}
+
+// TestLegacyCiphertextSelfHealsOnRead verifies rows encrypted before the
+// marker existed (bare base64 ciphertext) still decrypt on read and are
+// migrated to the marked format.
+func TestLegacyCiphertextSelfHealsOnRead(t *testing.T) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	encryptor, err := crypto.NewEncryptor(key)
+	if err != nil {
+		t.Fatalf("failed to create encryptor: %v", err)
+	}
+
+	dsn := "file:ent_legacyheal?mode=memory&cache=shared&_fk=1"
+	client, err := ent.Open("sqlite3", dsn)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer client.Close()
+
+	if err := client.Schema.Create(context.Background()); err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	ctx := context.Background()
+
+	user, err := client.User.Create().
+		SetUsername("testuser").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+
+	// Build legacy (unmarked) ciphertext and store it raw (no hooks yet).
+	sessionKey := "legacy-session-key"
+	marked, err := encryptor.Encrypt(sessionKey)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	legacy := strings.TrimPrefix(marked, crypto.EncryptedMarker)
+
+	auth, err := client.LastFMAuth.Create().
+		SetUser(user).
+		SetSessionKey(legacy).
+		SetUsername("lastfm_user").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("failed to create auth: %v", err)
+	}
+
+	RegisterEncryptionHooks(client, encryptor)
+
+	authFromDB, err := client.LastFMAuth.Get(ctx, auth.ID)
+	if err != nil {
+		t.Fatalf("failed to query legacy-ciphertext row: %v", err)
+	}
+	if authFromDB.SessionKey != sessionKey {
+		t.Errorf("session_key = %q, want %q", authFromDB.SessionKey, sessionKey)
+	}
+
+	// The row must have migrated to the marked format.
+	raw := rawColumnValue(t, dsn, "SELECT session_key FROM last_fm_auths WHERE id = ?", auth.ID)
+	if !crypto.IsEncrypted(raw) {
+		t.Fatalf("legacy row did not migrate: stored value %q has no marker", raw)
+	}
+	decrypted, err := encryptor.Decrypt(raw)
+	if err != nil {
+		t.Fatalf("failed to decrypt migrated value: %v", err)
+	}
+	if decrypted != sessionKey {
+		t.Errorf("migrated value decrypts to %q, want %q", decrypted, sessionKey)
 	}
 }

--- a/internal/database/hooks_test.go
+++ b/internal/database/hooks_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"spotter/ent"
+	"spotter/ent/navidromeauth"
 	"spotter/internal/crypto"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -793,5 +794,186 @@ func TestLegacyCiphertextSelfHealsOnRead(t *testing.T) {
 	}
 	if decrypted != sessionKey {
 		t.Errorf("migrated value decrypts to %q, want %q", decrypted, sessionKey)
+	}
+}
+
+// TestMarkerPrefixedPasswordRoundTrip covers the write-path hazard flagged in
+// review: a user password that literally starts with the enc:v1: marker must
+// still be encrypted on write (never stored as plaintext) and must round-trip
+// on read. Deciding by value shape in the write hook would store it raw and
+// then hard-error every read on GCM failure — the bricking bug again.
+func TestMarkerPrefixedPasswordRoundTrip(t *testing.T) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	encryptor, err := crypto.NewEncryptor(key)
+	if err != nil {
+		t.Fatalf("failed to create encryptor: %v", err)
+	}
+
+	dsn := "file:ent_markerprefix?mode=memory&cache=shared&_fk=1"
+	client, err := ent.Open("sqlite3", dsn)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer client.Close()
+
+	RegisterEncryptionHooks(client, encryptor)
+
+	if err := client.Schema.Create(context.Background()); err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	ctx := context.Background()
+
+	user, err := client.User.Create().
+		SetUsername("testuser").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+
+	// Adversarial user input: plaintext that impersonates the marker.
+	password := crypto.EncryptedMarker + "supersecret"
+
+	auth, err := client.NavidromeAuth.Create().
+		SetUser(user).
+		SetPassword(password).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("failed to create navidrome auth: %v", err)
+	}
+	if auth.Password != password {
+		t.Errorf("password after create = %q, want %q", auth.Password, password)
+	}
+
+	// The read must return the original plaintext, not error.
+	authFromDB, err := client.NavidromeAuth.Get(ctx, auth.ID)
+	if err != nil {
+		t.Fatalf("failed to query navidrome auth with marker-prefixed password: %v", err)
+	}
+	if authFromDB.Password != password {
+		t.Errorf("password after query = %q, want %q", authFromDB.Password, password)
+	}
+
+	// The stored value must be real ciphertext of the input, not the input itself.
+	raw := rawColumnValue(t, dsn, "SELECT password FROM navidrome_auths WHERE id = ?", auth.ID)
+	if raw == password {
+		t.Fatalf("marker-prefixed password stored as plaintext")
+	}
+	if !crypto.IsEncrypted(raw) {
+		t.Errorf("stored password %q does not carry the encryption marker", raw)
+	}
+	decrypted, err := encryptor.Decrypt(raw)
+	if err != nil {
+		t.Fatalf("failed to decrypt stored password: %v", err)
+	}
+	if decrypted != password {
+		t.Errorf("decrypted stored password = %q, want %q", decrypted, password)
+	}
+
+	// Update path must behave the same.
+	newPassword := crypto.EncryptedMarker + "another-secret"
+	if _, err := client.NavidromeAuth.UpdateOne(auth).SetPassword(newPassword).Save(ctx); err != nil {
+		t.Fatalf("failed to update password: %v", err)
+	}
+	updated, err := client.NavidromeAuth.Get(ctx, auth.ID)
+	if err != nil {
+		t.Fatalf("failed to query updated auth: %v", err)
+	}
+	if updated.Password != newPassword {
+		t.Errorf("updated password = %q, want %q", updated.Password, newPassword)
+	}
+}
+
+// TestSelfHealDoesNotClobberConcurrentUpdate verifies the compare-and-swap
+// guard on heal write-backs: when the stored value changes between the read
+// and the heal write, the heal must not overwrite the newer value.
+func TestSelfHealDoesNotClobberConcurrentUpdate(t *testing.T) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	encryptor, err := crypto.NewEncryptor(key)
+	if err != nil {
+		t.Fatalf("failed to create encryptor: %v", err)
+	}
+
+	dsn := "file:ent_healrace?mode=memory&cache=shared&_fk=1"
+	client, err := ent.Open("sqlite3", dsn)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer client.Close()
+
+	if err := client.Schema.Create(context.Background()); err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	ctx := context.Background()
+
+	user, err := client.User.Create().
+		SetUsername("testuser").
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+
+	// Legacy row stored raw (no hooks yet).
+	lookalike := "abcdefghijklmnopqrstuvwxyzABCDEF01234567"
+	auth, err := client.NavidromeAuth.Create().
+		SetUser(user).
+		SetPassword(lookalike).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("failed to create auth: %v", err)
+	}
+
+	RegisterEncryptionHooks(client, encryptor)
+
+	// Simulate the race deterministically: resolve the heal value the same
+	// way the interceptor does, then change the stored value before the
+	// conditional heal write fires.
+	_, healed, _, err := resolveEncryptedField(encryptor, lookalike)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if healed == "" {
+		t.Fatal("expected a heal value for the lookalike plaintext")
+	}
+
+	newPassword := "user-changed-password"
+	if _, err := client.NavidromeAuth.UpdateOne(auth).SetPassword(newPassword).Save(ctx); err != nil {
+		t.Fatalf("concurrent update: %v", err)
+	}
+	rawAfterUpdate := rawColumnValue(t, dsn, "SELECT password FROM navidrome_auths WHERE id = ?", auth.ID)
+
+	// The stale heal write: guarded by the old raw value, it must not match.
+	n, err := client.NavidromeAuth.Update().
+		Where(navidromeauth.ID(auth.ID), navidromeauth.Password(lookalike)).
+		SetPassword(healed).
+		Save(withSelfHeal(ctx))
+	if err != nil {
+		t.Fatalf("stale heal write errored: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("stale heal write modified %d row(s), want 0", n)
+	}
+
+	raw := rawColumnValue(t, dsn, "SELECT password FROM navidrome_auths WHERE id = ?", auth.ID)
+	if raw != rawAfterUpdate {
+		t.Errorf("stored value changed by stale heal: %q != %q", raw, rawAfterUpdate)
+	}
+
+	// The row still reads back as the user's new password.
+	got, err := client.NavidromeAuth.Get(ctx, auth.ID)
+	if err != nil {
+		t.Fatalf("read after stale heal: %v", err)
+	}
+	if got.Password != newPassword {
+		t.Errorf("password = %q, want %q", got.Password, newPassword)
 	}
 }


### PR DESCRIPTION
Implements the highest-severity finding of the remediation review. Part of epic #319. Governing: ADR-0006 (application-layer AES-256-GCM encryption), ADR-0021 (encryption key rotation).

## What / Why

`IsEncrypted()` treated any std-base64-decodable string with >= 29 decoded bytes as ciphertext. A 40-char alphanumeric password (or base64-alphabet API token) false-positived: the write hook skipped encryption (plaintext stored), then every read hit the decrypt interceptor, GCM authentication failed, and the query itself errored — the auth row was bricked until manual DB surgery.

### Changes

- **Explicit versioned marker** (`internal/crypto/encrypt.go`): new ciphertext is `enc:v1:` + base64(nonce||ct||tag). `IsEncrypted()` is now an exact marker-prefix check — never a heuristic. The marker alphabet (`:`) is disjoint from std base64, so marked values can never be confused with legacy ciphertext or plaintext. The old heuristic survives only as `LooksLikeLegacyCiphertext()`, explicitly documented as attempt-decryption-only, for the migration paths. `Decrypt()` accepts both marked and legacy (bare base64) input. Governing ADR-0006/ADR-0021 comments added throughout (previously the only major subsystem with zero).
- **Self-healing read path** (`internal/database/hooks.go`): interceptors resolve each stored value via `resolveEncryptedField()` — marker → decrypt (failure is a real error: wrong key/corruption); legacy base64 shape → attempt decrypt, on GCM failure treat as plaintext; in both legacy cases the row is best-effort re-encrypted with the marker (write hook sees the marker and stores it as-is). This path never errors the query. Plain plaintext keeps the existing encrypt-on-next-write behavior.
- **Key rotation handles all formats** (`cmd/admin/main.go`): `rotate-key` now resolves marked, legacy, and plaintext values and always writes back the marked format under the new key, so a rotated database is uniformly `enc:v1:`. Marked values that fail old-key decryption abort (definitive wrong key); ambiguous legacy-shaped values fall back to plaintext with a per-row warning. Pre-rotation old-key verification scans for a marked value first (definitive), then a decryptable legacy value.
- **ADR-0021 postgres/mysql guard** (`cmd/admin/main.go`): the "server not running" pre-rotation check was SQLite-only (BEGIN EXCLUSIVE probe). Postgres/MySQL now acquire a session-scoped advisory lock (`pg_try_advisory_lock` / `GET_LOCK`) to serialize rotations and refuse to run while other sessions are connected to the database. The pool is pinned to one connection (`SetMaxOpenConns(1)`) so session-scoped locks hold for the process lifetime. The connection check is documented as best-effort — stopping the server first remains mandatory per ADR-0021.

## Test evidence

- `make test`: all 27 packages pass, zero failures.
- `gofmt -l` clean on `internal/crypto`, `internal/database`, `cmd/admin`.
- New tests:
  - `TestBase64LookalikePasswordRoundTrip` — a 40-char base64-alphabet password is stored encrypted (marker verified via raw SQL) and round-trips (acceptance a).
  - `TestPlaintextLookalikeSelfHealsOnRead` — a pre-existing plaintext-that-looks-like-base64 row reads back correctly instead of erroring, and the stored value self-heals to marked ciphertext (acceptance b).
  - `TestLegacyCiphertextSelfHealsOnRead` — pre-marker ciphertext decrypts on read and migrates to the marked format.
  - `TestRunMixedMarkedLegacyAndPlaintextRows` / `TestRunLegacyCiphertextRotation` — rotation across marked + legacy + plaintext rows on SQLite (acceptance c); the postgres/mysql guard is exercised structurally and documented (no pg/mysql instance in CI — see code comments in `acquireRotationGuard`).
  - Marker-format unit tests: `TestEncryptProducesMarker`, `TestDecryptLegacyUnmarkedCiphertext`, `TestLooksLikeLegacyCiphertext`, plus `TestIsEncrypted` regression cases for the false-positive inputs.

### Deferred Design Doc Updates

`docs/adrs/` is a protected path in this remediation wave, so the issue's "Amend ADR-0006 to document the marker format" requirement is deferred. Proposed amendments for a follow-up:

- **ADR-0006**: document the `enc:v1:` versioned marker format (`enc:v1:` + base64(nonce||ct||tag)); update the "IsEncrypted() heuristic" consequence bullets to reflect that detection is now an exact marker check, with `LooksLikeLegacyCiphertext()` reserved for the self-healing migration path; describe the read-path self-heal (legacy ciphertext and heuristic-lookalike plaintext both re-encrypted with marker on read).
- **ADR-0021**: document that rotation migrates legacy/plaintext values to the marked format under the new key, and the postgres/mysql advisory-lock + other-sessions pre-rotation guard (plus its best-effort nature).
- **SPEC key-rotation**: ROT-004 (pre-rotation validation) and ROT-040 (decrypt with old key) semantics now include the legacy/plaintext fallback behavior described above.

Closes #335

🤖 Posted on behalf of `@joestump` by [Claude](https://claude.ai).