### PR TITLE
Adopt HTTPStatusError across all API clients; fix fatal-error classification

### DIFF
--- a/internal/enrichers/fanart/fanart.go
+++ b/internal/enrichers/fanart/fanart.go
@@ -11,6 +11,7 @@ import (
 	"spotter/ent"
 	"spotter/internal/config"
 	"spotter/internal/enrichers"
+	"spotter/internal/resilience"
 )
 
 const (
@@ -89,7 +90,8 @@ func (e *Enricher) doRequest(ctx context.Context, endpoint string) ([]byte, erro
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Fanart.tv API returned status %d", resp.StatusCode)
+		// Governing: ADR-0020, SPEC error-handling REQ-ERR-002/REQ-ERR-003
+		return nil, resilience.NewHTTPStatusError(resp.StatusCode, fmt.Errorf("Fanart.tv API returned status %d", resp.StatusCode))
 	}
 
 	var result []byte

--- a/internal/enrichers/images.go
+++ b/internal/enrichers/images.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/nfnt/resize"
 	_ "golang.org/x/image/webp"
+
+	"spotter/internal/resilience"
 )
 
 const (
@@ -56,7 +58,8 @@ func DownloadAndSaveImage(url, localPath string, logger *slog.Logger) (string, e
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("failed to download image, status: %s", resp.Status)
+		// Governing: ADR-0020, SPEC error-handling REQ-ERR-002/REQ-ERR-003
+		return "", resilience.NewHTTPStatusError(resp.StatusCode, fmt.Errorf("failed to download image, status: %s", resp.Status))
 	}
 
 	// Decode the image data. The blank import of image decoders allows

--- a/internal/enrichers/lastfm/lastfm.go
+++ b/internal/enrichers/lastfm/lastfm.go
@@ -14,6 +14,7 @@ import (
 	"spotter/ent"
 	"spotter/internal/config"
 	"spotter/internal/enrichers"
+	"spotter/internal/resilience"
 	tagsutil "spotter/internal/tags"
 )
 
@@ -95,7 +96,8 @@ func (e *Enricher) doRequest(ctx context.Context, method string, params url.Valu
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Last.fm API returned status %d", resp.StatusCode)
+		// Governing: ADR-0020, SPEC error-handling REQ-ERR-002/REQ-ERR-003
+		return nil, resilience.NewHTTPStatusError(resp.StatusCode, fmt.Errorf("Last.fm API returned status %d", resp.StatusCode))
 	}
 
 	var result []byte

--- a/internal/enrichers/lidarr/lidarr.go
+++ b/internal/enrichers/lidarr/lidarr.go
@@ -15,6 +15,7 @@ import (
 	"spotter/ent/user"
 	"spotter/internal/config"
 	"spotter/internal/enrichers"
+	"spotter/internal/resilience"
 	"spotter/internal/tags"
 	"strings"
 	"sync"
@@ -478,14 +479,16 @@ func (e *Enricher) doRequest(ctx context.Context, method, endpoint string, body 
 		if resp.StatusCode == http.StatusInternalServerError {
 			b, _ := io.ReadAll(resp.Body)
 			resp.Body.Close()
-			lastErr = fmt.Errorf("lidarr api error: %d - %s", resp.StatusCode, string(b))
+			// Governing: ADR-0020, SPEC error-handling REQ-ERR-002 (5xx retriable)
+			lastErr = resilience.NewHTTPStatusError(resp.StatusCode, fmt.Errorf("lidarr api error: %d - %s", resp.StatusCode, string(b)))
 			continue
 		}
 
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 			b, _ := io.ReadAll(resp.Body)
 			resp.Body.Close()
-			return fmt.Errorf("lidarr api error: %d - %s", resp.StatusCode, string(b))
+			// Governing: ADR-0020, SPEC error-handling REQ-ERR-002/REQ-ERR-003
+			return resilience.NewHTTPStatusError(resp.StatusCode, fmt.Errorf("lidarr api error: %d - %s", resp.StatusCode, string(b)))
 		}
 
 		if result != nil {

--- a/internal/enrichers/musicbrainz/musicbrainz.go
+++ b/internal/enrichers/musicbrainz/musicbrainz.go
@@ -14,6 +14,7 @@ import (
 	"spotter/ent"
 	"spotter/internal/config"
 	"spotter/internal/enrichers"
+	"spotter/internal/resilience"
 	tagsutil "spotter/internal/tags"
 )
 
@@ -125,11 +126,13 @@ func (e *Enricher) doRequest(ctx context.Context, endpoint string, params url.Va
 	}()
 
 	if resp.StatusCode == http.StatusServiceUnavailable || resp.StatusCode == http.StatusTooManyRequests {
-		return nil, fmt.Errorf("rate limited by MusicBrainz API")
+		// Governing: ADR-0020, SPEC error-handling REQ-ERR-002 (429/503 retriable)
+		return nil, resilience.NewHTTPStatusError(resp.StatusCode, fmt.Errorf("rate limited by MusicBrainz API"))
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("MusicBrainz API returned status %d", resp.StatusCode)
+		// Governing: ADR-0020, SPEC error-handling REQ-ERR-002/REQ-ERR-003
+		return nil, resilience.NewHTTPStatusError(resp.StatusCode, fmt.Errorf("MusicBrainz API returned status %d", resp.StatusCode))
 	}
 
 	var result []byte
@@ -497,7 +500,8 @@ func (e *Enricher) GetAlbumImages(ctx context.Context, album *ent.Album) ([]enri
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Cover Art Archive returned status %d", resp.StatusCode)
+		// Governing: ADR-0020, SPEC error-handling REQ-ERR-002/REQ-ERR-003
+		return nil, resilience.NewHTTPStatusError(resp.StatusCode, fmt.Errorf("Cover Art Archive returned status %d", resp.StatusCode))
 	}
 
 	var caaResponse struct {

--- a/internal/enrichers/navidrome/navidrome.go
+++ b/internal/enrichers/navidrome/navidrome.go
@@ -15,6 +15,7 @@ import (
 	"spotter/ent"
 	"spotter/internal/config"
 	"spotter/internal/enrichers"
+	"spotter/internal/resilience"
 	"spotter/internal/tags"
 )
 
@@ -122,7 +123,8 @@ func (e *Enricher) doRequest(ctx context.Context, method string, params url.Valu
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Navidrome API returned status %d", resp.StatusCode)
+		// Governing: ADR-0020, SPEC error-handling REQ-ERR-002/REQ-ERR-003
+		return nil, resilience.NewHTTPStatusError(resp.StatusCode, fmt.Errorf("Navidrome API returned status %d", resp.StatusCode))
 	}
 
 	var result []byte

--- a/internal/enrichers/spotify/spotify.go
+++ b/internal/enrichers/spotify/spotify.go
@@ -16,6 +16,7 @@ import (
 	"spotter/ent"
 	"spotter/internal/config"
 	"spotter/internal/enrichers"
+	"spotter/internal/resilience"
 	"spotter/internal/tags"
 
 	"golang.org/x/oauth2"
@@ -175,7 +176,8 @@ func (e *Enricher) doRequest(ctx context.Context, endpoint string) ([]byte, erro
 			resp.Body.Close()
 
 			if attempt == maxRetries {
-				return nil, fmt.Errorf("Spotify API rate limited after %d retries", maxRetries)
+				// Governing: ADR-0020, SPEC error-handling REQ-ERR-002 (429 retriable)
+				return nil, resilience.NewHTTPStatusError(http.StatusTooManyRequests, fmt.Errorf("Spotify API rate limited after %d retries", maxRetries))
 			}
 
 			retryAfter := defaultRetryAfter
@@ -212,17 +214,20 @@ func (e *Enricher) doRequest(ctx context.Context, endpoint string) ([]byte, erro
 		}
 
 		if resp.StatusCode == http.StatusUnauthorized {
-			return nil, fmt.Errorf("Spotify API unauthorized - token may be invalid")
+			// Governing: ADR-0020, SPEC error-handling REQ-ERR-003 (401 is fatal)
+			return nil, resilience.NewHTTPStatusError(resp.StatusCode, fmt.Errorf("Spotify API unauthorized - token may be invalid"))
 		}
 
 		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("Spotify API returned status %d", resp.StatusCode)
+			// Governing: ADR-0020, SPEC error-handling REQ-ERR-002/REQ-ERR-003
+			return nil, resilience.NewHTTPStatusError(resp.StatusCode, fmt.Errorf("Spotify API returned status %d", resp.StatusCode))
 		}
 
 		return body, nil
 	}
 
-	return nil, fmt.Errorf("Spotify API rate limited after %d retries", maxRetries)
+	// Governing: ADR-0020, SPEC error-handling REQ-ERR-002 (429 retriable)
+	return nil, resilience.NewHTTPStatusError(http.StatusTooManyRequests, fmt.Errorf("Spotify API rate limited after %d retries", maxRetries))
 }
 
 // Spotify API response types

--- a/internal/notifications/notifier_test.go
+++ b/internal/notifications/notifier_test.go
@@ -110,6 +110,53 @@ func TestDBNotifier_SendsOnFatalError(t *testing.T) {
 	}
 }
 
+// TestDBNotifier_SendsOnRevokedNavidromeCredentials verifies the fix for
+// issue #325: a revoked Navidrome credential — formatted exactly the way the
+// Navidrome client emits it ("navidrome API returned status: 401") — reaches
+// the email notification path, both via the typed HTTPStatusError the client
+// now constructs and via the string-matching fallback for unwrapped errors.
+// Governing: ADR-0020, ADR-0026, SPEC error-handling REQ-ERR-003
+func TestDBNotifier_SendsOnRevokedNavidromeCredentials(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			"typed_http_status_error",
+			services.NewHTTPStatusError(401, fmt.Errorf("navidrome API returned status: %d", 401)),
+		},
+		{
+			"legacy_unwrapped_string",
+			fmt.Errorf("navidrome API returned status: %d", 401),
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := setupTestDB(t)
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			mailer := &mockMailer{}
+			n := NewDBNotifier(client, mailer, 7, "http://localhost:8080", logger)
+
+			u, err := client.User.Create().
+				SetUsername(fmt.Sprintf("testuser_navidrome_revoked_%d", i)).
+				SetEmail("test@example.com").
+				SetPaginationSize(25).
+				Save(context.Background())
+			if err != nil {
+				t.Fatalf("create user: %v", err)
+			}
+
+			if err := n.NotifyIfNeeded(context.Background(), u, "navidrome", tt.err); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !mailer.sendCalled {
+				t.Error("should send email for revoked Navidrome credentials (401)")
+			}
+		})
+	}
+}
+
 func TestDBNotifier_CooldownPreventsSecondNotification(t *testing.T) {
 	client := setupTestDB(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))

--- a/internal/providers/lastfm/lastfm.go
+++ b/internal/providers/lastfm/lastfm.go
@@ -19,6 +19,7 @@ import (
 	"spotter/ent"
 	"spotter/internal/config"
 	"spotter/internal/providers"
+	"spotter/internal/resilience"
 )
 
 const (
@@ -352,7 +353,8 @@ func (p *Provider) doRequest(ctx context.Context, method string, params map[stri
 
 		// Try to read body for error details
 		body, _ := io.ReadAll(resp.Body)
-		lastErr = fmt.Errorf("last.fm api returned status %d: %s", resp.StatusCode, string(body))
+		// Governing: ADR-0020, SPEC error-handling REQ-ERR-002/REQ-ERR-003
+		lastErr = resilience.NewHTTPStatusError(resp.StatusCode, fmt.Errorf("last.fm api returned status %d: %s", resp.StatusCode, string(body)))
 
 		// If not a 500 error, don't retry
 		if resp.StatusCode < 500 {

--- a/internal/providers/navidrome/navidrome.go
+++ b/internal/providers/navidrome/navidrome.go
@@ -18,6 +18,7 @@ import (
 	"spotter/ent"
 	"spotter/internal/config"
 	"spotter/internal/providers"
+	"spotter/internal/resilience"
 )
 
 const (
@@ -128,7 +129,8 @@ func (p *Provider) authenticateInternalAPI(ctx context.Context) error {
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("navidrome login failed with status: %d", resp.StatusCode)
+		// Governing: ADR-0020, SPEC error-handling REQ-ERR-003 (401/403 are fatal)
+		return resilience.NewHTTPStatusError(resp.StatusCode, fmt.Errorf("navidrome login failed with status: %d", resp.StatusCode))
 	}
 
 	var loginResp struct {
@@ -187,7 +189,8 @@ func (p *Provider) getRecentlyPlayedFromInternalAPI(ctx context.Context, since t
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("navidrome internal API returned status: %d", resp.StatusCode)
+		// Governing: ADR-0020, SPEC error-handling REQ-ERR-002/REQ-ERR-003
+		return nil, resilience.NewHTTPStatusError(resp.StatusCode, fmt.Errorf("navidrome internal API returned status: %d", resp.StatusCode))
 	}
 
 	var songs []struct {
@@ -292,7 +295,8 @@ func (p *Provider) getNowPlayingFromSubsonic(ctx context.Context, since time.Tim
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("navidrome API returned status: %d", resp.StatusCode)
+		// Governing: ADR-0020, SPEC error-handling REQ-ERR-002/REQ-ERR-003
+		return nil, resilience.NewHTTPStatusError(resp.StatusCode, fmt.Errorf("navidrome API returned status: %d", resp.StatusCode))
 	}
 
 	var result struct {
@@ -402,7 +406,8 @@ func (p *Provider) GetPlaylists(ctx context.Context) ([]providers.Playlist, erro
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("navidrome API returned status: %d", resp.StatusCode)
+		// Governing: ADR-0020, SPEC error-handling REQ-ERR-002/REQ-ERR-003
+		return nil, resilience.NewHTTPStatusError(resp.StatusCode, fmt.Errorf("navidrome API returned status: %d", resp.StatusCode))
 	}
 
 	var result struct {
@@ -651,7 +656,8 @@ func (p *Provider) SyncPlaylist(ctx context.Context, playlist providers.SyncPlay
 		p.logger.Error("navidrome API returned non-OK status",
 			"status_code", resp.StatusCode,
 			"status", resp.Status)
-		return "", fmt.Errorf("navidrome API returned status: %d", resp.StatusCode)
+		// Governing: ADR-0020, SPEC error-handling REQ-ERR-002/REQ-ERR-003
+		return "", resilience.NewHTTPStatusError(resp.StatusCode, fmt.Errorf("navidrome API returned status: %d", resp.StatusCode))
 	}
 
 	var result struct {
@@ -729,7 +735,8 @@ func (p *Provider) updatePlaylistMetadata(ctx context.Context, playlistID, name,
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("navidrome API returned status: %d", resp.StatusCode)
+		// Governing: ADR-0020, SPEC error-handling REQ-ERR-002/REQ-ERR-003
+		return resilience.NewHTTPStatusError(resp.StatusCode, fmt.Errorf("navidrome API returned status: %d", resp.StatusCode))
 	}
 
 	var result struct {
@@ -804,7 +811,8 @@ func (p *Provider) DeletePlaylist(ctx context.Context, remotePlaylistID string) 
 	if resp.StatusCode != http.StatusOK {
 		p.logger.Error("navidrome API returned non-OK status",
 			"status_code", resp.StatusCode)
-		return fmt.Errorf("navidrome API returned status: %d", resp.StatusCode)
+		// Governing: ADR-0020, SPEC error-handling REQ-ERR-002/REQ-ERR-003
+		return resilience.NewHTTPStatusError(resp.StatusCode, fmt.Errorf("navidrome API returned status: %d", resp.StatusCode))
 	}
 
 	var result struct {
@@ -917,7 +925,8 @@ func (p *Provider) UpdatePlaylistTracks(ctx context.Context, remotePlaylistID st
 	if resp.StatusCode != http.StatusOK {
 		p.logger.Error("navidrome API returned non-OK status",
 			"status_code", resp.StatusCode)
-		return fmt.Errorf("navidrome API returned status: %d", resp.StatusCode)
+		// Governing: ADR-0020, SPEC error-handling REQ-ERR-002/REQ-ERR-003
+		return resilience.NewHTTPStatusError(resp.StatusCode, fmt.Errorf("navidrome API returned status: %d", resp.StatusCode))
 	}
 
 	var result struct {

--- a/internal/providers/spotify/spotify.go
+++ b/internal/providers/spotify/spotify.go
@@ -12,6 +12,7 @@ import (
 	"spotter/ent"
 	"spotter/internal/config"
 	"spotter/internal/providers"
+	"spotter/internal/resilience"
 
 	"golang.org/x/oauth2"
 	spotifyOAuth "golang.org/x/oauth2/spotify"
@@ -209,7 +210,8 @@ func (p *Provider) fetchUserProfile(ctx context.Context, accessToken string) (*s
 		}
 	}()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("spotify API returned status %d", resp.StatusCode)
+		// Governing: ADR-0020, SPEC error-handling REQ-ERR-002/REQ-ERR-003
+		return nil, resilience.NewHTTPStatusError(resp.StatusCode, fmt.Errorf("spotify API returned status %d", resp.StatusCode))
 	}
 
 	var user spotifyUser
@@ -284,7 +286,8 @@ func (p *Provider) GetRecentListens(ctx context.Context, since time.Time, callba
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("spotify API returned status %d", resp.StatusCode)
+		// Governing: ADR-0020, SPEC error-handling REQ-ERR-002/REQ-ERR-003
+		return resilience.NewHTTPStatusError(resp.StatusCode, fmt.Errorf("spotify API returned status %d", resp.StatusCode))
 	}
 
 	var result recentlyPlayedResponse
@@ -390,7 +393,8 @@ func (p *Provider) GetPlaylists(ctx context.Context) ([]providers.Playlist, erro
 			if err := resp.Body.Close(); err != nil {
 				p.logger.Warn("failed to close response body", "error", err)
 			}
-			return nil, fmt.Errorf("spotify API returned status %d", resp.StatusCode)
+			// Governing: ADR-0020, SPEC error-handling REQ-ERR-002/REQ-ERR-003
+			return nil, resilience.NewHTTPStatusError(resp.StatusCode, fmt.Errorf("spotify API returned status %d", resp.StatusCode))
 		}
 
 		var result playlistsResponse

--- a/internal/resilience/httperror.go
+++ b/internal/resilience/httperror.go
@@ -1,0 +1,31 @@
+// Governing: ADR-0020 (exponential backoff and circuit breaker), SPEC error-handling REQ-ERR-001 through REQ-ERR-004
+//
+// Package resilience holds typed errors shared by provider/enricher HTTP
+// clients and the services-layer error classifier. It lives below both
+// internal/providers and internal/services so that clients can construct
+// typed errors without creating an import cycle (internal/services imports
+// internal/providers).
+package resilience
+
+// HTTPStatusError wraps an error with an HTTP status code so that
+// services.ClassifyError can classify it on the typed path instead of
+// falling back to string matching.
+// Governing: SPEC error-handling REQ-ERR-004
+type HTTPStatusError struct {
+	StatusCode int
+	Err        error
+}
+
+func (e *HTTPStatusError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *HTTPStatusError) Unwrap() error {
+	return e.Err
+}
+
+// NewHTTPStatusError creates a new HTTPStatusError. All provider and
+// enricher HTTP clients MUST wrap non-2xx responses with this constructor.
+func NewHTTPStatusError(statusCode int, err error) *HTTPStatusError {
+	return &HTTPStatusError{StatusCode: statusCode, Err: err}
+}

--- a/internal/services/resilience.go
+++ b/internal/services/resilience.go
@@ -2,16 +2,20 @@
 package services
 
 import (
+	"encoding/json"
+	"encoding/xml"
 	"errors"
 	"math"
 	"math/rand/v2"
 	"net"
 	"net/http"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
 
 	"spotter/internal/providers"
+	"spotter/internal/resilience"
 )
 
 // ErrorClass represents the classification of an error as retriable or fatal.
@@ -37,27 +41,23 @@ func (c ErrorClass) String() string {
 }
 
 // HTTPStatusError wraps an error with an HTTP status code for classification.
-type HTTPStatusError struct {
-	StatusCode int
-	Err        error
-}
-
-func (e *HTTPStatusError) Error() string {
-	return e.Err.Error()
-}
-
-func (e *HTTPStatusError) Unwrap() error {
-	return e.Err
-}
+// It is defined in internal/resilience so that provider and enricher HTTP
+// clients can construct it without importing internal/services (which would
+// create an import cycle via internal/providers). This alias keeps the
+// services-side API unchanged.
+// Governing: SPEC error-handling REQ-ERR-004
+type HTTPStatusError = resilience.HTTPStatusError
 
 // NewHTTPStatusError creates a new HTTPStatusError.
 func NewHTTPStatusError(statusCode int, err error) *HTTPStatusError {
-	return &HTTPStatusError{StatusCode: statusCode, Err: err}
+	return resilience.NewHTTPStatusError(statusCode, err)
 }
 
 // ClassifyError classifies an error as retriable or fatal.
-// It inspects the error chain for HTTPStatusError (HTTP status-based classification)
-// and net.Error (network-level classification).
+// It prefers typed classification: HTTPStatusError (HTTP status-based),
+// net.Error (network-level), and JSON/XML decode errors (unparseable
+// response bodies). Message-based string matching is kept only as a
+// fallback for errors that reach the classifier unwrapped.
 // Governing: SPEC error-handling REQ-ERR-001 through REQ-ERR-004
 func ClassifyError(err error) ErrorClass {
 	if err == nil {
@@ -85,6 +85,18 @@ func ClassifyError(err error) ErrorClass {
 	var opErr *net.OpError
 	if errors.As(err, &opErr) {
 		return ErrorClassRetriable
+	}
+
+	// Unparseable response bodies (malformed JSON/XML) indicate an API
+	// contract change and are fatal. Truncated-body I/O errors (io.EOF,
+	// io.ErrUnexpectedEOF) intentionally remain retriable — they usually
+	// indicate transient network truncation, not a contract change.
+	// Governing: SPEC error-handling REQ-ERR-003 (unparseable response body)
+	var jsonSyntaxErr *json.SyntaxError
+	var jsonTypeErr *json.UnmarshalTypeError
+	var xmlSyntaxErr *xml.SyntaxError
+	if errors.As(err, &jsonSyntaxErr) || errors.As(err, &jsonTypeErr) || errors.As(err, &xmlSyntaxErr) {
+		return ErrorClassFatal
 	}
 
 	// Heuristic: check error message for common patterns
@@ -143,6 +155,19 @@ func isRetriableErrorMessage(msg string) bool {
 	return false
 }
 
+// fatalStatusPattern matches error messages that embed a fatal HTTP status
+// code, covering the formats the clients actually emit (fallback only — all
+// clients now wrap non-2xx responses in resilience.NewHTTPStatusError):
+//
+//	"navidrome API returned status: 401"     (colon before the code)
+//	"navidrome login failed with status: 403"
+//	"spotify API returned status 401"        (no colon)
+//	"last.fm api returned status 401: ..."   (code followed by body)
+//	"lidarr api error: 403 - ..."
+//
+// Governing: ADR-0020, SPEC error-handling REQ-ERR-003
+var fatalStatusPattern = regexp.MustCompile(`(?:status|error):? *(?:401|403|404)\b`)
+
 func isFatalErrorMessage(msg string) bool {
 	fatalPatterns := []string{
 		"unauthorized",
@@ -151,19 +176,16 @@ func isFatalErrorMessage(msg string) bool {
 		"invalid credentials",
 		"revoked",
 		"deactivated",
-		// Catch plain "returned status 4xx" messages from providers that
-		// don't wrap errors in HTTPStatusError (e.g. "spotify API returned status 403").
-		// 4xx responses are client errors and won't succeed on retry.
-		"status 401",
-		"status 403",
-		"status 404",
 	}
 	for _, pattern := range fatalPatterns {
 		if strings.Contains(msg, pattern) {
 			return true
 		}
 	}
-	return false
+	// Catch "returned status 4xx" style messages from errors that were not
+	// wrapped in HTTPStatusError. 401/403/404 are client errors that won't
+	// succeed on retry.
+	return fatalStatusPattern.MatchString(msg)
 }
 
 // BackoffState tracks per-provider error state.
@@ -207,11 +229,20 @@ const (
 	backoffMaxDelay  = 30 * time.Minute
 )
 
-// CalculateBackoff computes the next retry delay using exponential backoff with jitter.
-// delay = min(30s * 2^consecutiveFailures, 30m) * jitter[0.75, 1.25]
+// CalculateBackoff computes the retry delay after the Nth consecutive failure.
+// delay = min(30s * 2^(consecutiveFailures-1), 30m) * jitter[0.75, 1.25]
+//
+// RecordFailure increments ConsecutiveFailures before calling this, so the
+// first failure passes consecutiveFailures=1 and must wait ~30s (base delay),
+// the second ~60s, the third ~120s — matching SPEC error-handling
+// Scenarios 1-2 and ADR-0020 ("30s, 60s, 120s, ... up to 30 minutes").
 // Governing: SPEC error-handling REQ-BACK-001, REQ-BACK-002, REQ-BACK-003
 func CalculateBackoff(consecutiveFailures int) time.Duration {
-	delay := float64(backoffBaseDelay) * math.Pow(2, float64(consecutiveFailures))
+	exponent := consecutiveFailures - 1
+	if exponent < 0 {
+		exponent = 0
+	}
+	delay := float64(backoffBaseDelay) * math.Pow(2, float64(exponent))
 	if delay > float64(backoffMaxDelay) {
 		delay = float64(backoffMaxDelay)
 	}

--- a/internal/services/resilience.go
+++ b/internal/services/resilience.go
@@ -99,13 +99,16 @@ func ClassifyError(err error) ErrorClass {
 		return ErrorClassFatal
 	}
 
-	// Heuristic: check error message for common patterns
+	// Heuristic: check error message for common patterns. Fatal patterns are
+	// checked first so a fatal status embedded in a message wins even when
+	// the appended response body happens to contain a retriable-looking word
+	// (e.g. `last.fm api returned status 401: ...timeout...`).
 	msg := strings.ToLower(err.Error())
-	if isRetriableErrorMessage(msg) {
-		return ErrorClassRetriable
-	}
 	if isFatalErrorMessage(msg) {
 		return ErrorClassFatal
+	}
+	if isRetriableErrorMessage(msg) {
+		return ErrorClassRetriable
 	}
 
 	// Default to retriable for unknown errors — prefer retry over giving up
@@ -116,10 +119,20 @@ func ClassifyError(err error) ErrorClass {
 // Governing: SPEC error-handling REQ-ERR-002 (retriable statuses), REQ-ERR-003 (fatal statuses)
 func classifyHTTPStatus(statusCode int) ErrorClass {
 	switch statusCode {
-	case http.StatusTooManyRequests, // 429
+	case http.StatusRequestTimeout, // 408 — a timeout, retriable per REQ-ERR-002
+		http.StatusTooManyRequests,     // 429
 		http.StatusBadGateway,          // 502
 		http.StatusServiceUnavailable,  // 503
 		http.StatusInternalServerError: // 500
+		return ErrorClassRetriable
+	case http.StatusNotFound: // 404
+		// Deliberate: 404 is retriable. Reverse proxies (e.g. Traefik) return
+		// transient 404s while a backend's route is dropped during a container
+		// redeploy; classifying that fatal would permanently stop sync with a
+		// misleading "reconnect credentials" notification. A genuinely wrong
+		// base URL keeps retrying at the 30-minute backoff cap instead —
+		// invalid configuration is REQ-ERR-003's concern at config-validation
+		// time, not per-request.
 		return ErrorClassRetriable
 	case http.StatusUnauthorized, // 401
 		http.StatusForbidden: // 403
@@ -128,6 +141,8 @@ func classifyHTTPStatus(statusCode int) ErrorClass {
 		if statusCode >= 500 {
 			return ErrorClassRetriable
 		}
+		// Remaining 4xx (400, 405, 422, ...) are client errors that will not
+		// succeed on retry — the request itself is wrong.
 		return ErrorClassFatal
 	}
 }
@@ -165,8 +180,11 @@ func isRetriableErrorMessage(msg string) bool {
 //	"last.fm api returned status 401: ..."   (code followed by body)
 //	"lidarr api error: 403 - ..."
 //
+// 404 is deliberately excluded to stay consistent with the typed path in
+// classifyHTTPStatus: transient 404s from reverse proxies during redeploys
+// must remain retriable.
 // Governing: ADR-0020, SPEC error-handling REQ-ERR-003
-var fatalStatusPattern = regexp.MustCompile(`(?:status|error):? *(?:401|403|404)\b`)
+var fatalStatusPattern = regexp.MustCompile(`(?:status|error):? *(?:401|403)\b`)
 
 func isFatalErrorMessage(msg string) bool {
 	fatalPatterns := []string{
@@ -183,7 +201,7 @@ func isFatalErrorMessage(msg string) bool {
 		}
 	}
 	// Catch "returned status 4xx" style messages from errors that were not
-	// wrapped in HTTPStatusError. 401/403/404 are client errors that won't
+	// wrapped in HTTPStatusError. 401/403 are credential errors that won't
 	// succeed on retry.
 	return fatalStatusPattern.MatchString(msg)
 }

--- a/internal/services/resilience_test.go
+++ b/internal/services/resilience_test.go
@@ -1,6 +1,8 @@
 package services_test
 
 import (
+	"encoding/json"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"net"
@@ -120,6 +122,93 @@ func TestClassifyError_MessageBasedFatal(t *testing.T) {
 	}
 }
 
+// TestClassifyError_RealWorldClientFormats exercises the string-matching
+// fallback against the exact formats the provider/enricher clients emit,
+// including the colon variant Navidrome uses ("returned status: 401") that
+// the old "status 401" patterns failed to match, causing revoked credentials
+// to retry forever (issue #325).
+func TestClassifyError_RealWorldClientFormats(t *testing.T) {
+	fatal := []struct {
+		name string
+		msg  string
+	}{
+		{"navidrome_colon_401", "navidrome API returned status: 401"},
+		{"navidrome_colon_403", "navidrome API returned status: 403"},
+		{"navidrome_login_401", "navidrome login failed with status: 401"},
+		{"navidrome_internal_401", "navidrome internal API returned status: 401"},
+		{"lastfm_provider_401", "last.fm api returned status 401: invalid session key"},
+		{"lidarr_error_401", "lidarr api error: 401 - unauthorized"},
+		{"fanart_403", "Fanart.tv API returned status 403"},
+	}
+	for _, tt := range fatal {
+		t.Run("fatal_"+tt.name, func(t *testing.T) {
+			assert.Equal(t, services.ErrorClassFatal, services.ClassifyError(errors.New(tt.msg)))
+		})
+	}
+
+	// 5xx/429 messages must stay retriable — no behavior change for transient errors
+	retriable := []struct {
+		name string
+		msg  string
+	}{
+		{"navidrome_colon_503", "navidrome API returned status: 503"},
+		{"spotify_500", "spotify API returned status 500"},
+		{"lastfm_502", "last.fm api returned status 502: bad gateway"},
+	}
+	for _, tt := range retriable {
+		t.Run("retriable_"+tt.name, func(t *testing.T) {
+			assert.Equal(t, services.ErrorClassRetriable, services.ClassifyError(errors.New(tt.msg)))
+		})
+	}
+}
+
+// TestClassifyError_NavidromeRevokedCredentials_Typed simulates the error the
+// Navidrome provider now returns for a revoked credential: a 401 wrapped in
+// HTTPStatusError with the provider's exact message format.
+func TestClassifyError_NavidromeRevokedCredentials_Typed(t *testing.T) {
+	err := services.NewHTTPStatusError(401, fmt.Errorf("navidrome API returned status: %d", 401))
+	assert.Equal(t, services.ErrorClassFatal, services.ClassifyError(err))
+
+	// Still fatal when wrapped further up the call chain
+	wrapped := fmt.Errorf("failed to fetch listens: %w", err)
+	assert.Equal(t, services.ErrorClassFatal, services.ClassifyError(wrapped))
+}
+
+// Governing: SPEC error-handling REQ-ERR-003 (unparseable response body is fatal)
+func TestClassifyError_DecodeErrorsFatal(t *testing.T) {
+	var jsonTarget struct {
+		Name string `json:"name"`
+	}
+	jsonSyntaxErr := json.Unmarshal([]byte("<html>502 Bad Gateway</html>"), &jsonTarget)
+	require.Error(t, jsonSyntaxErr)
+
+	jsonTypeErr := json.Unmarshal([]byte(`{"name": 42}`), &jsonTarget)
+	require.Error(t, jsonTypeErr)
+
+	var xmlTarget struct {
+		Name string `xml:"name"`
+	}
+	xmlSyntaxErr := xml.Unmarshal([]byte("<lfm><name>x</wrong></lfm>"), &xmlTarget)
+	require.Error(t, xmlSyntaxErr)
+	var asXMLSyntax *xml.SyntaxError
+	require.ErrorAs(t, xmlSyntaxErr, &asXMLSyntax)
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"json_syntax", jsonSyntaxErr},
+		{"json_type", jsonTypeErr},
+		{"xml_syntax", xmlSyntaxErr},
+		{"wrapped_json_syntax", fmt.Errorf("failed to decode response: %w", jsonSyntaxErr)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, services.ErrorClassFatal, services.ClassifyError(tt.err))
+		})
+	}
+}
+
 func TestClassifyError_5xxRetriable(t *testing.T) {
 	// Any 5xx status should be retriable
 	err := services.NewHTTPStatusError(504, fmt.Errorf("gateway timeout"))
@@ -152,16 +241,35 @@ func TestCalculateBackoff_ExponentialGrowth(t *testing.T) {
 }
 
 func TestCalculateBackoff_FirstFailure(t *testing.T) {
-	// First failure: base = 30s * 2^1 = 60s, with jitter [45s, 75s]
+	// First failure: base = 30s * 2^(1-1) = 30s, with jitter [22.5s, 37.5s]
+	// Governing: SPEC error-handling Scenario 1 (first failure waits ~30s)
 	for i := 0; i < 10; i++ {
 		delay := services.CalculateBackoff(1)
-		assert.GreaterOrEqual(t, delay, 45*time.Second, "first failure delay should be >= 45s (60s * 0.75)")
-		assert.LessOrEqual(t, delay, 75*time.Second, "first failure delay should be <= 75s (60s * 1.25)")
+		assert.GreaterOrEqual(t, delay, 22500*time.Millisecond, "first failure delay should be >= 22.5s (30s * 0.75)")
+		assert.LessOrEqual(t, delay, 37500*time.Millisecond, "first failure delay should be <= 37.5s (30s * 1.25)")
+	}
+}
+
+// TestCalculateBackoff_SpecScenarioProgression verifies the 30/60/120s
+// progression promised by SPEC error-handling Scenario 2 and ADR-0020,
+// given that RecordFailure increments the counter before calculating.
+func TestCalculateBackoff_SpecScenarioProgression(t *testing.T) {
+	expected := map[int]time.Duration{
+		1: 30 * time.Second,  // after 1st failure
+		2: 60 * time.Second,  // after 2nd failure
+		3: 120 * time.Second, // after 3rd failure
+	}
+	for failures, base := range expected {
+		for i := 0; i < 10; i++ {
+			delay := services.CalculateBackoff(failures)
+			assert.GreaterOrEqual(t, delay, time.Duration(float64(base)*0.75), "failures=%d", failures)
+			assert.LessOrEqual(t, delay, time.Duration(float64(base)*1.25), "failures=%d", failures)
+		}
 	}
 }
 
 func TestCalculateBackoff_ZeroFailures(t *testing.T) {
-	// Zero consecutive failures: base = 30s * 2^0 = 30s, with jitter [22.5s, 37.5s]
+	// Zero consecutive failures clamps to the base delay: 30s, with jitter [22.5s, 37.5s]
 	for i := 0; i < 10; i++ {
 		delay := services.CalculateBackoff(0)
 		assert.GreaterOrEqual(t, delay, time.Duration(float64(22500)*float64(time.Millisecond)))
@@ -213,6 +321,25 @@ func TestBackoffManager_RecordRetriableFailure(t *testing.T) {
 	assert.False(t, state.IsFatal)
 	assert.False(t, state.NextRetryAt.IsZero(), "nextRetryAt should be set")
 	assert.NotNil(t, state.LastError)
+}
+
+// TestBackoffManager_FirstFailureDelayMatchesSpec verifies end to end that
+// the first recorded retriable failure schedules a retry ~30s out (RecordFailure
+// increments before CalculateBackoff, which now compensates with 2^(n-1)).
+// Governing: SPEC error-handling Scenarios 1-2, REQ-BACK-001
+func TestBackoffManager_FirstFailureDelayMatchesSpec(t *testing.T) {
+	mgr := services.NewBackoffManager()
+	key := services.BackoffKey{UserID: 1, ProviderType: providers.TypeNavidrome}
+
+	before := time.Now()
+	mgr.RecordFailure(key, fmt.Errorf("connection timeout"), services.ErrorClassRetriable)
+
+	state, ok := mgr.GetState(key)
+	require.True(t, ok)
+	delay := state.NextRetryAt.Sub(before)
+	// 30s with +/-25% jitter, small slack for elapsed wall time
+	assert.GreaterOrEqual(t, delay, 22*time.Second, "first retry should be ~30s out, not ~60s")
+	assert.LessOrEqual(t, delay, 38*time.Second, "first retry should be ~30s out, not ~60s")
 }
 
 func TestBackoffManager_RecordFatalFailure(t *testing.T) {

--- a/internal/services/resilience_test.go
+++ b/internal/services/resilience_test.go
@@ -21,7 +21,9 @@ import (
 
 func TestClassifyError_HTTPRetriableStatuses(t *testing.T) {
 	retriableCodes := []int{
+		http.StatusRequestTimeout,      // 408 — a timeout, retriable per REQ-ERR-002
 		http.StatusTooManyRequests,     // 429
+		http.StatusNotFound,            // 404 — transient behind reverse proxies during redeploys
 		http.StatusBadGateway,          // 502
 		http.StatusServiceUnavailable,  // 503
 		http.StatusInternalServerError, // 500
@@ -108,10 +110,10 @@ func TestClassifyError_MessageBasedFatal(t *testing.T) {
 		{"unauthorized_message", "unauthorized: token expired"},
 		{"forbidden_message", "forbidden: insufficient permissions"},
 		{"invalid_api_key", "invalid api key provided"},
-		// Providers that return plain "returned status NNN" messages without HTTPStatusError
+		// Providers that return plain "returned status NNN" messages without HTTPStatusError.
+		// 404 is deliberately absent: it classifies retriable (transient behind proxies).
 		{"plain_status_401", "spotify API returned status 401"},
 		{"plain_status_403", "spotify API returned status 403"},
-		{"plain_status_404", "spotify API returned status 404"},
 	}
 
 	for _, tt := range tests {
@@ -146,13 +148,17 @@ func TestClassifyError_RealWorldClientFormats(t *testing.T) {
 		})
 	}
 
-	// 5xx/429 messages must stay retriable — no behavior change for transient errors
+	// 5xx/429/404 messages must stay retriable — no behavior change for
+	// transient errors, and 404s can be transient route-drops behind a
+	// reverse proxy during redeploys.
 	retriable := []struct {
 		name string
 		msg  string
 	}{
 		{"navidrome_colon_503", "navidrome API returned status: 503"},
+		{"navidrome_colon_404", "navidrome API returned status: 404"},
 		{"spotify_500", "spotify API returned status 500"},
+		{"spotify_404", "spotify API returned status 404"},
 		{"lastfm_502", "last.fm api returned status 502: bad gateway"},
 	}
 	for _, tt := range retriable {
@@ -160,6 +166,31 @@ func TestClassifyError_RealWorldClientFormats(t *testing.T) {
 			assert.Equal(t, services.ErrorClassRetriable, services.ClassifyError(errors.New(tt.msg)))
 		})
 	}
+}
+
+// TestClassifyError_FatalPatternWinsOverRetriableSubstring pins the fallback
+// ordering: a fatal status embedded in a message must win even when the
+// appended response body contains a retriable-looking word like "timeout".
+func TestClassifyError_FatalPatternWinsOverRetriableSubstring(t *testing.T) {
+	err := errors.New("last.fm api returned status 401: upstream request timeout while validating session")
+	assert.Equal(t, services.ErrorClassFatal, services.ClassifyError(err))
+}
+
+// TestClassifyError_Transient404_Typed pins the deliberate decision that a
+// typed 404 is retriable: reverse proxies (e.g. Traefik) return transient
+// 404s while a backend's route is dropped during a container redeploy, and a
+// fatal classification would permanently stop sync with a misleading
+// "reconnect credentials" notification.
+func TestClassifyError_Transient404_Typed(t *testing.T) {
+	err := services.NewHTTPStatusError(http.StatusNotFound, fmt.Errorf("navidrome API returned status: %d", http.StatusNotFound))
+	assert.Equal(t, services.ErrorClassRetriable, services.ClassifyError(err))
+}
+
+// TestClassifyError_RequestTimeout408_Typed pins 408 as retriable — it is a
+// timeout and REQ-ERR-002 requires timeouts to be retriable.
+func TestClassifyError_RequestTimeout408_Typed(t *testing.T) {
+	err := services.NewHTTPStatusError(http.StatusRequestTimeout, fmt.Errorf("spotify API returned status %d", http.StatusRequestTimeout))
+	assert.Equal(t, services.ErrorClassRetriable, services.ClassifyError(err))
 }
 
 // TestClassifyError_NavidromeRevokedCredentials_Typed simulates the error the

--- a/internal/services/sync_error_test.go
+++ b/internal/services/sync_error_test.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
 	"testing"
 	"time"
 
+	"spotter/ent"
 	"spotter/ent/enttest"
 	"spotter/internal/config"
 	"spotter/internal/events"
@@ -191,4 +193,130 @@ func TestSyncer_HistoryCallbackError_DoesNotPersistPartialData(t *testing.T) {
 	listens, err := client.Listen.Query().All(context.Background())
 	require.NoError(t, err)
 	assert.Empty(t, listens, "no listens should be created when provider fails")
+}
+
+// countingProvider is a mock provider that counts how many times it is called.
+type countingProvider struct {
+	providerType providers.Type
+	err          error
+	calls        int
+}
+
+func (m *countingProvider) Type() providers.Type {
+	return m.providerType
+}
+
+func (m *countingProvider) GetRecentListens(ctx context.Context, since time.Time, callback func([]providers.Track) error) error {
+	m.calls++
+	return m.err
+}
+
+func (m *countingProvider) GetPlaylists(ctx context.Context) ([]providers.Playlist, error) {
+	m.calls++
+	return nil, m.err
+}
+
+func (m *countingProvider) CreatePlaylist(ctx context.Context, name, description string, tracks []providers.Track) error {
+	return nil
+}
+
+// recordingNotifier records NotifyIfNeeded calls made by the syncer.
+type recordingNotifier struct {
+	notifyCalls int
+	lastErr     error
+}
+
+func (n *recordingNotifier) NotifyIfNeeded(_ context.Context, _ *ent.User, _ string, syncErr error) error {
+	n.notifyCalls++
+	n.lastErr = syncErr
+	return nil
+}
+
+func (n *recordingNotifier) ClearCooldown(_ context.Context, _ int, _ string) error {
+	return nil
+}
+
+func (n *recordingNotifier) SendTest(_ context.Context, _ *ent.User) error {
+	return nil
+}
+
+// TestSyncer_RevokedNavidromeCredentials_FatalStopsRetryAndNotifies simulates
+// revoked Navidrome credentials end to end (issue #325): the provider returns
+// a 401 wrapped in HTTPStatusError with the exact message format the Navidrome
+// client emits ("navidrome API returned status: 401"), the error classifies
+// fatal, backoff blocks further retries, and NotifyIfNeeded fires.
+// Governing: ADR-0020, ADR-0026, SPEC error-handling REQ-ERR-003, REQ-STATE-004, REQ-NOTIFY-001
+func TestSyncer_RevokedNavidromeCredentials_FatalStopsRetryAndNotifies(t *testing.T) {
+	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	t.Cleanup(func() { client.Close() })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	bus := events.NewBus()
+	notifier := &recordingNotifier{}
+	syncer := services.NewSyncer(client, &config.Config{}, logger, bus, notifier)
+
+	user, err := client.User.Create().SetUsername("testuser").Save(context.Background())
+	require.NoError(t, err)
+	_, err = client.NavidromeAuth.Create().
+		SetUser(user).
+		SetPassword("revokedpassword").
+		Save(context.Background())
+	require.NoError(t, err)
+
+	// Error formatted exactly the way internal/providers/navidrome does
+	revokedErr := services.NewHTTPStatusError(
+		http.StatusUnauthorized,
+		fmt.Errorf("navidrome API returned status: %d", http.StatusUnauthorized),
+	)
+	assert.Equal(t, services.ErrorClassFatal, services.ClassifyError(revokedErr),
+		"a 401 from Navidrome must classify fatal")
+
+	prov := &countingProvider{providerType: providers.TypeNavidrome, err: revokedErr}
+	syncer.Register(mockFactory(prov))
+
+	// First sync — hits the 401, records fatal state, notifies
+	require.NoError(t, syncer.Sync(context.Background(), user))
+	require.GreaterOrEqual(t, notifier.notifyCalls, 1, "NotifyIfNeeded must fire for a fatal error")
+	assert.Equal(t, services.ErrorClassFatal, services.ClassifyError(notifier.lastErr),
+		"the error reaching the notifier must classify fatal")
+	callsAfterFirst := prov.calls
+	require.GreaterOrEqual(t, callsAfterFirst, 1)
+	notifiesAfterFirst := notifier.notifyCalls
+
+	// Second sync — provider is blocked by the fatal flag: backoff stops,
+	// no more provider calls, no repeated notifications
+	require.NoError(t, syncer.Sync(context.Background(), user))
+	assert.Equal(t, callsAfterFirst, prov.calls,
+		"provider must not be retried after a fatal error (backoff stops)")
+	assert.Equal(t, notifiesAfterFirst, notifier.notifyCalls,
+		"no repeat notification while the fatal error persists")
+}
+
+// TestSyncer_LegacyNavidromeErrorString_FallbackClassifiesFatal covers the
+// string-matching fallback: an unwrapped error carrying Navidrome's colon
+// format still classifies fatal and stops retries.
+func TestSyncer_LegacyNavidromeErrorString_FallbackClassifiesFatal(t *testing.T) {
+	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&cache=shared&_fk=1")
+	t.Cleanup(func() { client.Close() })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	bus := events.NewBus()
+	notifier := &recordingNotifier{}
+	syncer := services.NewSyncer(client, &config.Config{}, logger, bus, notifier)
+
+	user, err := client.User.Create().SetUsername("testuser2").Save(context.Background())
+	require.NoError(t, err)
+
+	legacyErr := fmt.Errorf("navidrome API returned status: %d", http.StatusUnauthorized)
+	assert.Equal(t, services.ErrorClassFatal, services.ClassifyError(legacyErr))
+
+	prov := &countingProvider{providerType: providers.TypeNavidrome, err: legacyErr}
+	syncer.Register(mockFactory(prov))
+
+	require.NoError(t, syncer.Sync(context.Background(), user))
+	require.GreaterOrEqual(t, notifier.notifyCalls, 1, "NotifyIfNeeded must fire via the string fallback")
+	callsAfterFirst := prov.calls
+
+	require.NoError(t, syncer.Sync(context.Background(), user))
+	assert.Equal(t, callsAfterFirst, prov.calls, "backoff must stop after fatal classification")
 }


### PR DESCRIPTION
## What / Why

Part of epic #318. `internal/services/resilience.go` defined a typed `HTTPStatusError` that no client constructed, so error classification ran entirely on string matching — and the fatal patterns (`"status 401"`) did not match Navidrome's real format (`"navidrome API returned status: 401"`, with a colon). Revoked Navidrome credentials were classified retriable, retried forever on capped backoff, and never triggered the fatal toast or the ADR-0026 sync-failure email.

Governing artifacts: ADR-0020 (exponential backoff and circuit breaker), ADR-0026 (sync-failure email notifications), SPEC error-handling REQ-ERR-003.

### Changes

- **New `internal/resilience` package** containing `HTTPStatusError` + `NewHTTPStatusError`. This is required because `internal/services` imports `internal/providers`, so providers/enrichers cannot import `internal/services` without an import cycle. The package location matches the spec's implementation note ("new struct in `internal/services/` or `internal/resilience/`"). `internal/services` keeps `HTTPStatusError` as a type alias and re-exports the constructor, so all existing call sites and tests are unchanged.
- **Typed adoption in every client**: all non-2xx responses in the Navidrome provider (login, internal API, all Subsonic call sites), Spotify provider, Last.fm provider, the Spotify, Last.fm, MusicBrainz (+ Cover Art Archive), Fanart.tv, Navidrome, and Lidarr enrichers, and the shared image downloader (`internal/enrichers/images.go`) are wrapped in `resilience.NewHTTPStatusError`. `Error()` delegates to the inner error, so log output and message-based behavior are byte-for-byte unchanged.
- **`ClassifyError` prefers the typed path**; string matching is now explicitly a fallback and extended (via a `(status|error):? *(401|403)` regex) to match the formats clients actually emit, including Navidrome's colon variant and Lidarr's `api error: 401 - ...` format. In the fallback, fatal patterns are checked **before** retriable substrings so a fatal status embedded in a message wins even when the appended response body contains a retriable-looking word (e.g. `status 401: ...timeout...`).
- **Explicit status-code decisions in `classifyHTTPStatus`** (this branch went live once clients started constructing the typed error, so each 4xx is now deliberate):
  - **408 → retriable.** It is a timeout; REQ-ERR-002 requires timeouts to be retriable.
  - **404 → retriable (deliberate).** Reverse proxies (e.g. Traefik) return transient 404s while a backend's route is dropped during a container redeploy; a fatal classification would permanently stop sync with a misleading "reconnect credentials" email. A genuinely wrong base URL keeps retrying at the 30-minute backoff cap instead — invalid configuration is REQ-ERR-003's concern at config-validation time, not per-request. The string-fallback regex excludes 404 for the same reason, keeping typed and fallback paths consistent. Both pinned with tests.
  - **401/403 → fatal** (REQ-ERR-003); **remaining 4xx (400, 405, 422, ...) → fatal** — the request itself is wrong and will not succeed on retry; **5xx → retriable**.
- **REQ-ERR-003**: JSON/XML decode errors (`json.SyntaxError`, `json.UnmarshalTypeError`, `xml.SyntaxError`) classify **fatal** (unparseable response body = API contract change) instead of falling through to default-retriable. Truncated-body I/O errors (`io.EOF`/`ErrUnexpectedEOF`) deliberately remain retriable — those indicate transient network truncation, not a contract change.
- **Backoff-scenario math — decision: fixed the code.** `CalculateBackoff` now uses `2^(consecutiveFailures-1)`, so with `RecordFailure`'s increment-before-calculate the first retry waits ~30s, then ~60s, ~120s — matching SPEC error-handling Scenarios 1-2 **and** ADR-0020's consequences section ("30s, 60s, 120s, ... up to 30 minutes"). The previous code produced 60/120/240s. No spec amendment needed for the scenarios; see deferred notes below on REQ-BACK-001 wording.

### Test evidence

- `make test` (full suite) passes; `go test ./internal/services/... -race -count=1` passes.
- `gofmt -l .` clean; `go vet ./internal/...` clean.
- Acceptance grep: `grep -rn "NewHTTPStatusError" internal/providers internal/enrichers` shows adoption in every client (25 call sites including the shared image downloader).
- Key tests:
  - `TestSyncer_RevokedNavidromeCredentials_FatalStopsRetryAndNotifies` — end-to-end: a 401 formatted exactly as the Navidrome client emits it classifies `ErrorClassFatal`, the provider is not called again on the next sync (backoff stops), and `NotifyIfNeeded` fires exactly once.
  - `TestSyncer_LegacyNavidromeErrorString_FallbackClassifiesFatal` — same guarantees through the string fallback for unwrapped errors.
  - `TestDBNotifier_SendsOnRevokedNavidromeCredentials` — the real `DBNotifier` sends the ADR-0026 email for both the typed error and the legacy string format.
  - `TestClassifyError_RealWorldClientFormats` — fatal for every real client format (Navidrome colon, Last.fm, Lidarr, Fanart.tv); 5xx/404 variants of the same formats stay retriable.
  - `TestClassifyError_Transient404_Typed`, `TestClassifyError_RequestTimeout408_Typed`, `TestClassifyError_FatalPatternWinsOverRetriableSubstring` — pin the review-driven decisions.
  - `TestClassifyError_DecodeErrorsFatal`, `TestCalculateBackoff_SpecScenarioProgression`, `TestBackoffManager_FirstFailureDelayMatchesSpec`.

### Deferred Design Doc Updates

- SPEC error-handling REQ-BACK-001 states `delay = min(baseDelay * 2^consecutiveFailures, maxDelay)`, which literally contradicts the spec's own Scenarios 1-2 (first failure → ~30s implies `2^(n-1)` when `n` is the post-increment failure count). The code follows the scenarios and ADR-0020. Suggest amending REQ-BACK-001 to `2^(consecutiveFailures-1)` or clarifying that `consecutiveFailures` in the formula means failures *before* the current one.
- SPEC error-handling REQ-BACK-001 vs REQ-BACK-002 self-contradiction on jitter-after-clamp: the formula applies `jitterFactor` **after** the `min(..., maxDelay)` clamp, so at the cap the actual delay ranges up to 37.5 minutes, while REQ-BACK-002 says the delay "MUST NOT exceed 30 minutes regardless". The code (and pre-existing tests) apply jitter after the clamp per the REQ-BACK-001 formula. Suggest amending REQ-BACK-002 to "MUST NOT exceed 30 minutes before jitter" or clamping after jitter in a follow-up.
- Consider documenting the 404-retriable and 408-retriable decisions in SPEC error-handling REQ-ERR-002 (neither status is currently enumerated).

(Spec files are protected paths — not edited here.)

Closes #325

Refs: #318, ADR-0020, ADR-0026, SPEC error-handling

🤖 Posted on behalf of `@joestump` by [Claude](https://claude.ai).